### PR TITLE
Add Javadoc for api interfaces

### DIFF
--- a/src/java/magmac/api/None.java
+++ b/src/java/magmac/api/None.java
@@ -5,6 +5,10 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
+/**
+ * Option variant representing the absence of a value.
+ */
+
 public class None<T> implements Option<T> {
     @Override
     public <R> Option<R> map(Function<T, R> mapper) {

--- a/src/java/magmac/api/Option.java
+++ b/src/java/magmac/api/Option.java
@@ -5,22 +5,79 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
+/**
+ * Functional container for an optional value.
+ */
+
 public interface Option<T> {
+    /**
+     * Transforms the contained value if present.
+     *
+     * @param mapper function to apply to the inner value
+     * @param <R>    the resulting type
+     * @return an {@code Option} containing the mapped value or empty
+     */
     <R> Option<R> map(Function<T, R> mapper);
 
+    /**
+     * Checks whether a value is present.
+     *
+     * @return {@code true} when a value exists
+     */
     boolean isPresent();
 
+    /**
+     * Returns the value if present or obtains a fallback.
+     *
+     * @param other supplier used when the option is empty
+     * @return the contained value or the supplier result
+     */
     T orElseGet(Supplier<T> other);
 
+    /**
+     * Checks whether no value is present.
+     *
+     * @return {@code true} when empty
+     */
     boolean isEmpty();
 
+    /**
+     * Maps the value to another {@code Option} if present and flattens the result.
+     *
+     * @param mapper mapping function returning an option
+     * @param <R>    the resulting type
+     * @return the mapped option or empty
+     */
     <R> Option<R> flatMap(Function<T, Option<R>> mapper);
 
+    /**
+     * Returns the value if present or a default.
+     *
+     * @param other fallback value
+     * @return the contained value or {@code other}
+     */
     T orElse(T other);
 
+    /**
+     * Keeps the value only when it satisfies the predicate.
+     *
+     * @param predicate test applied to the value
+     * @return this option when the test passes otherwise an empty option
+     */
     Option<T> filter(Predicate<T> predicate);
 
+    /**
+     * Uses the supplied option when empty.
+     *
+     * @param other supplier of an alternative option
+     * @return this option or the supplied one when empty
+     */
     Option<T> or(Supplier<Option<T>> other);
 
+    /**
+     * Invokes the consumer when a value is present.
+     *
+     * @param consumer action to perform on the contained value
+     */
     void ifPresent(Consumer<T> consumer);
 }

--- a/src/java/magmac/api/Some.java
+++ b/src/java/magmac/api/Some.java
@@ -5,6 +5,10 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
+/**
+ * Option variant representing a present value.
+ */
+
 public record Some<T>(T value) implements Option<T> {
     @Override
     public <R> Option<R> map(Function<T, R> mapper) {

--- a/src/java/magmac/api/Tuple2.java
+++ b/src/java/magmac/api/Tuple2.java
@@ -1,4 +1,8 @@
 package magmac.api;
 
+/**
+ * Generic pair of values.
+ */
+
 public record Tuple2<A, B>(A left, B right) {
 }

--- a/src/java/magmac/api/collect/TupleCollector.java
+++ b/src/java/magmac/api/collect/TupleCollector.java
@@ -3,6 +3,10 @@ package magmac.api.collect;
 import magmac.api.Tuple2;
 import magmac.api.iter.collect.Collector;
 
+/**
+ * Collects a pair of iterables using individual collectors for each side.
+ */
+
 public record TupleCollector<A, AC, B, BC>(
         Collector<A, AC> leftCollector,
         Collector<B, BC> rightCollector

--- a/src/java/magmac/api/collect/list/JVMList.java
+++ b/src/java/magmac/api/collect/list/JVMList.java
@@ -12,6 +12,10 @@ import magmac.api.iter.collect.ListCollector;
 import java.util.ArrayList;
 import java.util.function.BiFunction;
 
+/**
+ * {@link List} implementation backed by a Java {@link java.util.List}.
+ */
+
 public record JVMList<T>(java.util.List<T> elements) implements List<T> {
     public JVMList() {
         this(new ArrayList<>());

--- a/src/java/magmac/api/collect/list/List.java
+++ b/src/java/magmac/api/collect/list/List.java
@@ -6,32 +6,78 @@ import magmac.api.iter.Iter;
 
 import java.util.function.BiFunction;
 
+/**
+ * Immutable list abstraction.
+ */
+
 public interface List<T> {
+    /**
+     * Returns a new list with {@code element} appended to the end.
+     */
     List<T> addLast(T element);
 
+    /**
+     * Creates an iterator over the elements.
+     */
     Iter<T> iter();
 
+    /**
+     * Appends all elements from {@code others}.
+     */
     List<T> addAllLast(List<T> others);
 
+    /**
+     * Removes all occurrences found in {@code others}.
+     */
     List<T> removeAll(List<T> others);
 
+    /**
+     * Retrieves the element at {@code index}.
+     */
     T get(int index);
 
+    /**
+     * Sorts using the provided comparator.
+     */
     List<T> sort(BiFunction<T, T, Integer> sorter);
 
+    /**
+     * Returns the last element if present.
+     */
     Option<T> findLast();
 
+    /**
+     * Checks if {@code element} exists in the list.
+     */
     boolean contains(T element);
 
+    /**
+     * Number of elements in the list.
+     */
     int size();
 
+    /**
+     * Removes and returns the last element.
+     */
     Option<Tuple2<List<T>, T>> popLast();
 
+    /**
+     * Removes and returns the first element.
+     */
     Option<Tuple2<T, List<T>>> popFirst();
 
+    /**
+     * Returns a new list with {@code element} added at the front.
+     */
     List<T> addFirst(T element);
 
+    /**
+     * Checks whether the list has no elements.
+     */
     boolean isEmpty();
 
+    /**
+     * Iterates over the list along with element indices.
+     */
     Iter<Tuple2<Integer, T>> iterWithIndices();
 }

--- a/src/java/magmac/api/collect/list/Lists.java
+++ b/src/java/magmac/api/collect/list/Lists.java
@@ -3,15 +3,28 @@ package magmac.api.collect.list;
 import java.util.ArrayList;
 import java.util.Arrays;
 
+/**
+ * Factory and helper methods for working with {@link List} values.
+ */
+
 public final class Lists {
+    /**
+     * Creates a list containing the given elements.
+     */
     public static <T> List<T> of(T... elements) {
         return new JVMList<>(new ArrayList<>(Arrays.asList(elements)));
     }
 
+    /**
+     * Returns an empty list.
+     */
     public static <T> List<T> empty() {
         return new JVMList<>();
     }
 
+    /**
+     * Creates a list repeating {@code element} {@code size} times.
+     */
     public static <T> List<T> repeat(T element, int size) {
         List<T> copy = Lists.empty();
         var i = 0;

--- a/src/java/magmac/api/collect/map/JVMMap.java
+++ b/src/java/magmac/api/collect/map/JVMMap.java
@@ -12,6 +12,10 @@ import java.util.HashMap;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+/**
+ * {@link Map} implementation backed by a Java {@link java.util.Map}.
+ */
+
 public
 record JVMMap<K, V>(java.util.Map<K, V> map) implements Map<K, V> {
     @Override

--- a/src/java/magmac/api/collect/map/Map.java
+++ b/src/java/magmac/api/collect/map/Map.java
@@ -7,20 +7,48 @@ import magmac.api.iter.Iter;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+/**
+ * Immutable map abstraction.
+ */
+
 public interface Map<K, V> {
+    /**
+     * Retrieves a value by key or returns {@code other} when absent.
+     */
     V getOrDefault(K key, V other);
 
+    /**
+     * Creates an iterator over entries of this map.
+     */
     Iter<Tuple2<K, V>> iter();
 
+    /**
+     * Associates {@code key} with {@code value} and returns the updated map.
+     */
     Map<K, V> put(K key, V value);
 
+    /**
+     * Checks whether {@code key} exists.
+     */
     boolean containsKey(K key);
 
+    /**
+     * Retrieves the value mapped to {@code key}.
+     */
     V get(K key);
 
+    /**
+     * Tests whether the map has no entries.
+     */
     boolean isEmpty();
 
+    /**
+     * Updates an existing key with {@code mapper} or puts a supplied value if missing.
+     */
     Map<K, V> mapOrPut(K key, Function<V, V> mapper, Supplier<V> supplier);
 
+    /**
+     * Removes a key returning the updated map and removed value.
+     */
     Option<Tuple2<Map<K, V>, V>> removeByKey(K key);
 }

--- a/src/java/magmac/api/collect/map/MapCollector.java
+++ b/src/java/magmac/api/collect/map/MapCollector.java
@@ -3,6 +3,10 @@ package magmac.api.collect.map;
 import magmac.api.Tuple2;
 import magmac.api.iter.collect.Collector;
 
+/**
+ * Collector for building a {@link Map} from key-value pairs.
+ */
+
 public record MapCollector<K, V>() implements Collector<Tuple2<K, V>, Map<K, V>> {
     @Override
     public Map<K, V> createInitial() {

--- a/src/java/magmac/api/collect/map/Maps.java
+++ b/src/java/magmac/api/collect/map/Maps.java
@@ -2,7 +2,14 @@ package magmac.api.collect.map;
 
 import java.util.HashMap;
 
+/**
+ * Factory methods for creating {@link Map} instances.
+ */
+
 public final class Maps {
+    /**
+     * Returns an empty map instance.
+     */
     public static <K, V> Map<K, V> empty() {
         return new JVMMap<>(new HashMap<>());
     }

--- a/src/java/magmac/api/error/Error.java
+++ b/src/java/magmac/api/error/Error.java
@@ -1,5 +1,12 @@
 package magmac.api.error;
 
+/**
+ * Marker interface for compiler errors.
+ */
+
 public interface Error {
+    /**
+     * Returns a human-readable description.
+     */
     String display();
 }

--- a/src/java/magmac/api/head/EmptyHead.java
+++ b/src/java/magmac/api/head/EmptyHead.java
@@ -3,6 +3,10 @@ package magmac.api.head;
 import magmac.api.None;
 import magmac.api.Option;
 
+/**
+ * {@link Head} that yields no elements.
+ */
+
 public class EmptyHead<T> implements Head<T> {
     @Override
     public Option<T> next() {

--- a/src/java/magmac/api/head/FlatMapHead.java
+++ b/src/java/magmac/api/head/FlatMapHead.java
@@ -4,6 +4,10 @@ import magmac.api.None;
 import magmac.api.iter.Iter;
 
 import magmac.api.Option;
+
+/**
+ * {@link Head} that applies a mapping function producing nested iterables.
+ */
 import java.util.function.Function;
 
 public class FlatMapHead<T, R> implements Head<R> {

--- a/src/java/magmac/api/head/Head.java
+++ b/src/java/magmac/api/head/Head.java
@@ -2,6 +2,13 @@ package magmac.api.head;
 
 import magmac.api.Option;
 
+/**
+ * Source of elements for an iteration.
+ */
+
 interface Head<T> {
+    /**
+     * Produces the next element or an empty option when done.
+     */
     Option<T> next();
 }

--- a/src/java/magmac/api/head/HeadedIter.java
+++ b/src/java/magmac/api/head/HeadedIter.java
@@ -10,6 +10,10 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+/**
+ * Iterator implementation backed by a {@link Head}.
+ */
+
 public record HeadedIter<T>(Head<T> head) implements Iter<T> {
     @Override
     public <R, X> Result<R, X> foldToResult(R initial, BiFunction<R, T, Result<R, X>> folder) {

--- a/src/java/magmac/api/head/RangeHead.java
+++ b/src/java/magmac/api/head/RangeHead.java
@@ -4,6 +4,10 @@ import magmac.api.None;
 import magmac.api.Option;
 import magmac.api.Some;
 
+/**
+ * {@link Head} producing a range of integers.
+ */
+
 public class RangeHead implements Head<Integer> {
     private final int length;
     private int counter;

--- a/src/java/magmac/api/head/SingleHead.java
+++ b/src/java/magmac/api/head/SingleHead.java
@@ -4,6 +4,10 @@ import magmac.api.None;
 import magmac.api.Option;
 import magmac.api.Some;
 
+/**
+ * {@link Head} yielding a single element.
+ */
+
 public class SingleHead<T> implements Head<T> {
     private final T element;
     private boolean retrieved;

--- a/src/java/magmac/api/iter/Iter.java
+++ b/src/java/magmac/api/iter/Iter.java
@@ -8,20 +8,48 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+/**
+ * Lazy sequence of elements with common operations.
+ */
+
 public interface Iter<T> {
+    /**
+     * Folds elements with a function that may produce a result.
+     */
     <R, X> Result<R, X> foldToResult(R initial, BiFunction<R, T, Result<R, X>> folder);
 
+    /**
+     * Lazily maps each element using {@code mapper}.
+     */
     <R> Iter<R> map(Function<T, R> mapper);
 
+    /**
+     * Folds elements from left to right.
+     */
     <R> R fold(R initial, BiFunction<R, T, R> folder);
 
+    /**
+     * Collects elements using a provided collector.
+     */
     <C> C collect(Collector<T, C> collector);
 
+    /**
+     * Retains only elements that satisfy the predicate.
+     */
     Iter<T> filter(Predicate<T> predicate);
 
+    /**
+     * Retrieves the next element or returns empty when exhausted.
+     */
     Option<T> next();
 
+    /**
+     * Maps each element to another iterator and flattens the result.
+     */
     <R> Iter<R> flatMap(Function<T, Iter<R>> mapper);
 
+    /**
+     * Appends another iterator lazily.
+     */
     Iter<T> concat(Iter<T> other);
 }

--- a/src/java/magmac/api/iter/Iters.java
+++ b/src/java/magmac/api/iter/Iters.java
@@ -6,21 +6,35 @@ import magmac.api.head.HeadedIter;
 import magmac.api.head.RangeHead;
 import magmac.api.head.SingleHead;
 
+/**
+ * Factory methods for creating {@link Iter} instances.
+ */
+
 public final class Iters {
     private static <T> Iter<T> fromArray(T[] array) {
-        return new HeadedIter<>(new RangeHead(array.length)).map((Integer index) -> array[index]);
+        return new HeadedIter<>(new RangeHead(array.length))
+                .map((Integer index) -> array[index]);
     }
 
+    /**
+     * Creates an iterator from an {@link Option}, yielding zero or one element.
+     */
     public static <T> Iter<T> fromOption(Option<T> option) {
         return option
                 .<Iter<T>>map((T t) -> new HeadedIter<>(new SingleHead<>(t)))
                 .orElseGet(() -> new HeadedIter<>(new EmptyHead<>()));
     }
 
+    /**
+     * Creates an iterator from the provided values.
+     */
     public static <T> Iter<T> fromValues(T... values) {
         return Iters.fromArray(values);
     }
 
+    /**
+     * Returns an iterator with no elements.
+     */
     public static <T> Iter<T> empty() {
         return new HeadedIter<>(new EmptyHead<>());
     }

--- a/src/java/magmac/api/iter/collect/Collector.java
+++ b/src/java/magmac/api/iter/collect/Collector.java
@@ -1,7 +1,17 @@
 package magmac.api.iter.collect;
 
+/**
+ * Fold-style collector used by {@link magmac.api.iter.Iter#collect}.
+ */
+
 public interface Collector<T, C> {
+    /**
+     * Provides the initial accumulation value.
+     */
     C createInitial();
 
+    /**
+     * Accumulates {@code element} into {@code current}.
+     */
     C fold(C current, T element);
 }

--- a/src/java/magmac/api/iter/collect/Joiner.java
+++ b/src/java/magmac/api/iter/collect/Joiner.java
@@ -4,6 +4,10 @@ import magmac.api.None;
 import magmac.api.Option;
 import magmac.api.Some;
 
+/**
+ * Collector that concatenates strings using a delimiter.
+ */
+
 public record Joiner(String delimiter) implements Collector<String, Option<String>> {
     public Joiner() {
         this("");

--- a/src/java/magmac/api/iter/collect/ListCollector.java
+++ b/src/java/magmac/api/iter/collect/ListCollector.java
@@ -3,6 +3,10 @@ package magmac.api.iter.collect;
 import magmac.api.collect.list.List;
 import magmac.api.collect.list.Lists;
 
+/**
+ * Collector that accumulates elements into a {@link magmac.api.collect.list.List}.
+ */
+
 public record ListCollector<T>() implements Collector<T, List<T>> {
     @Override
     public List<T> createInitial() {

--- a/src/java/magmac/api/iter/collect/Max.java
+++ b/src/java/magmac/api/iter/collect/Max.java
@@ -2,6 +2,10 @@ package magmac.api.iter.collect;
 
 import java.util.Optional;
 
+/**
+ * Collector that determines the maximum integer.
+ */
+
 public record Max() implements Collector<Integer, Optional<Integer>> {
     @Override
     public Optional<Integer> createInitial() {

--- a/src/java/magmac/api/iter/collect/ResultCollector.java
+++ b/src/java/magmac/api/iter/collect/ResultCollector.java
@@ -4,6 +4,10 @@ import magmac.api.Tuple2;
 import magmac.api.result.Ok;
 import magmac.api.result.Result;
 
+/**
+ * Collector that transforms {@link magmac.api.result.Result} values while accumulating.
+ */
+
 public record ResultCollector<T, C, X>(
         Collector<T, C> collector
 ) implements Collector<Result<T, X>, Result<C, X>> {

--- a/src/java/magmac/api/package-info.java
+++ b/src/java/magmac/api/package-info.java
@@ -1,0 +1,10 @@
+/**
+ * Common functional utilities used throughout the compiler.
+ * <p>
+ * The <code>magmac.api</code> package contains simple implementations of
+ * <em>option</em>, <em>result</em> and collection data structures. These
+ * abstractions are inspired by functional programming languages and are used
+ * within the compiler pipeline.
+ * </p>
+ */
+package magmac.api;

--- a/src/java/magmac/api/result/Err.java
+++ b/src/java/magmac/api/result/Err.java
@@ -5,6 +5,10 @@ import magmac.api.Tuple2;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+/**
+ * Error variant of {@link Result}.
+ */
+
 public record Err<T, X>(X error) implements Result<T, X> {
     @Override
     public <R> Result<R, X> mapValue(Function<T, R> mapper) {

--- a/src/java/magmac/api/result/Ok.java
+++ b/src/java/magmac/api/result/Ok.java
@@ -5,6 +5,10 @@ import magmac.api.Tuple2;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+/**
+ * Successful variant of {@link Result}.
+ */
+
 public record Ok<T, X>(T value) implements Result<T, X> {
     @Override
     public <R> Result<R, X> mapValue(Function<T, R> mapper) {

--- a/src/java/magmac/api/result/Result.java
+++ b/src/java/magmac/api/result/Result.java
@@ -5,14 +5,33 @@ import magmac.api.Tuple2;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+/**
+ * Represents either a successful value or an error value.
+ */
+
 public interface Result<T, X> {
+    /**
+     * Maps the success value using {@code mapper}.
+     */
     <R> Result<R, X> mapValue(Function<T, R> mapper);
 
+    /**
+     * Combines this result with another result produced by {@code supplier}.
+     */
     <R> Result<Tuple2<T, R>, X> and(Supplier<Result<R, X>> supplier);
 
+    /**
+     * Executes one of the functions depending on whether this is ok or err.
+     */
     <R> R match(Function<T, R> whenOk, Function<X, R> whenErr);
 
+    /**
+     * Maps to another result and flattens the output.
+     */
     <R> Result<R, X> flatMapValue(Function<T, Result<R, X>> mapper);
 
+    /**
+     * Maps the error value using {@code mapper}.
+     */
     <R> Result<T, R> mapErr(Function<X, R> mapper);
 }


### PR DESCRIPTION
## Summary
- document all interfaces under `magmac.api`
- cover interface methods with Javadoc
- document helper classes `Iters`, `Lists` and `Maps`

## Testing
- `npm test` *(fails: Error: no test specified)*
- `pnpm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_683f869796648321881f202a56cf9f8e