### PR TITLE
Update CI workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,38 @@
+name: Build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm install
+
+      # The TypeScript version of the compiler isn't ready yet so we skip
+      # compiling .ts files in CI to avoid noisy failures.
+      # Once the TypeScript pipeline is stable this step can run `npx tsc`.
+      - name: Skip TypeScript build
+        run: echo "Skipping TypeScript build"
+
+      - name: Build Java
+        run: |
+          mkdir -p out
+          javac --release 21 --enable-preview -d out $(find src/java -name '*.java')

--- a/README.md
+++ b/README.md
@@ -32,3 +32,10 @@ This will scan the sources, run the compiler pipeline and write the generated ou
 
 See [`docs/architecture.md`](docs/architecture.md) for an overview of how the compiler is structured.
 For details on how the PlantUML class diagram is generated see [`docs/diagram-generation.md`](docs/diagram-generation.md).
+
+## Continuous Integration
+
+The repository is built on every pull request using a GitHub Actions workflow.
+It compiles the Java sources with JDK&nbsp;21 and preview features enabled.
+Compilation of the generated TypeScript is currently **skipped** because the
+compiler's TypeScript pipeline is still under development.


### PR DESCRIPTION
## Summary
- disable TypeScript compilation in the GitHub Actions workflow
- note in README that CI skips the TypeScript build

## Testing
- `npm install`
- `javac --release 21 --enable-preview -d out $(find src/java -name '*.java')`


------
https://chatgpt.com/codex/tasks/task_e_683f8f04b6208321a4ad934ac0b3cc7d