### PR TITLE
Fix locale-sensitive enum handling

### DIFF
--- a/src/java/magmac/app/lang/java/JavaDeserializers.java
+++ b/src/java/magmac/app/lang/java/JavaDeserializers.java
@@ -121,7 +121,7 @@ public final class JavaDeserializers {
     }
 
     private static Option<CompileResult<Conditional>> deserializeConditional(ConditionalType type, Node node) {
-        return Destructors.destructWithType(type.name().toLowerCase(), node).map(deserializer -> deserializer.withNode("condition", JavaDeserializers::deserializeValueOrError)
+        return Destructors.destructWithType(type.text(), node).map(deserializer -> deserializer.withNode("condition", JavaDeserializers::deserializeValueOrError)
                 .complete(value -> new Conditional(type, value)));
     }
 

--- a/src/java/magmac/app/lang/java/JavaLang.java
+++ b/src/java/magmac/app/lang/java/JavaLang.java
@@ -188,7 +188,7 @@ public class JavaLang {
         }
 
         public Option<CompileResult<Structure>> deserialize(Node node) {
-            return Destructors.destructWithType(this.type().name().toLowerCase(), node)
+            return Destructors.destructWithType(this.type().text(), node)
                     .map((InitialDestructor deserializer) -> JavaStructureNodeDeserializer.deserializeHelper(this.type(), deserializer));
         }
     }
@@ -373,9 +373,19 @@ public class JavaLang {
     }
 
     public enum JavaStructureType {
-        Class,
-        Record,
-        Enum,
-        Interface
+        Class("class"),
+        Record("record"),
+        Enum("enum"),
+        Interface("interface");
+
+        private final String text;
+
+        JavaStructureType(String text) {
+            this.text = text;
+        }
+
+        public String text() {
+            return this.text;
+        }
     }
 }

--- a/src/java/magmac/app/lang/node/ConditionalType.java
+++ b/src/java/magmac/app/lang/node/ConditionalType.java
@@ -4,5 +4,15 @@ package magmac.app.lang.node;
  * The kind of conditional statement, such as {@code if} or {@code while}.
  */
 public enum ConditionalType {
-    While, If
+    While("while"), If("if");
+
+    private final String text;
+
+    ConditionalType(String text) {
+        this.text = text;
+    }
+
+    public String text() {
+        return this.text;
+    }
 }

--- a/src/java/magmac/app/lang/node/PlantUMLStructure.java
+++ b/src/java/magmac/app/lang/node/PlantUMLStructure.java
@@ -19,6 +19,6 @@ public record PlantUMLStructure(PlantUMLStructureType type, String name) impleme
 
     @Override
     public Node serialize() {
-        return new MapNode(this.type.name().toLowerCase()).withString("name", this.name);
+        return new MapNode(this.type.text()).withString("name", this.name);
     }
 }

--- a/src/java/magmac/app/lang/node/PlantUMLStructureType.java
+++ b/src/java/magmac/app/lang/node/PlantUMLStructureType.java
@@ -4,5 +4,15 @@ package magmac.app.lang.node;
  * The kinds of structures supported in PlantUML diagrams.
  */
 public enum PlantUMLStructureType {
-    Class, Interface, Enum
+    Class("class"), Interface("interface"), Enum("enum");
+
+    private final String text;
+
+    PlantUMLStructureType(String text) {
+        this.text = text;
+    }
+
+    public String text() {
+        return this.text;
+    }
 }

--- a/src/java/magmac/app/lang/web/TypescriptLang.java
+++ b/src/java/magmac/app/lang/web/TypescriptLang.java
@@ -89,7 +89,7 @@ public final class TypescriptLang {
 
         @Override
         public Node serialize() {
-            return new MapNode(this.type.name().toLowerCase())
+            return new MapNode(this.type.text())
                     .withString("name", this.value.name())
                     .withNodeListAndSerializer("modifiers", this.value.modifiers(), Serializable::serialize)
                     .withNodeListAndSerializer("members", this.value.members(), Serializable::serialize)
@@ -156,7 +156,7 @@ public final class TypescriptLang {
 
         @Override
         public Node serialize() {
-            return new MapNode(this.type.name().toLowerCase())
+            return new MapNode(this.type.text())
                     .withNodeSerialized("condition", this.condition);
         }
     }
@@ -367,8 +367,18 @@ public final class TypescriptLang {
     }
 
     public enum StructureType {
-        Class,
-        Enum,
-        Interface
+        Class("class"),
+        Enum("enum"),
+        Interface("interface");
+
+        private final String text;
+
+        StructureType(String text) {
+            this.text = text;
+        }
+
+        public String text() {
+            return this.text;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- avoid calling `toLowerCase` with default locale
- give enums explicit text representations
- update serialization/deserialization to use these strings

## Testing
- `javac --release 21 --enable-preview -d out $(find src/java -name '*.java')`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_683f964e87608321bb783418b4ed9d18