### PR TITLE
Add Java tests to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,3 +36,9 @@ jobs:
         run: |
           mkdir -p out
           javac --release 21 --enable-preview -d out $(find src/java -name '*.java')
+
+      - name: Run Java tests
+        run: |
+          curl -L -o junit-platform-console-standalone.jar https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/1.10.1/junit-platform-console-standalone-1.10.1.jar
+          javac --release 21 --enable-preview -cp junit-platform-console-standalone.jar:out -d out $(find test/java -name '*.java')
+          java --enable-preview -jar junit-platform-console-standalone.jar --class-path out --scan-class-path


### PR DESCRIPTION
## Summary
- run JUnit tests in `/test/java`

## Testing
- `npm test` *(fails: no tests specified)*
- `javac --release 21 --enable-preview -d out $(find src/java -name '*.java')`
- `curl -L -o junit-platform-console-standalone.jar https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/1.10.1/junit-platform-console-standalone-1.10.1.jar`
- `javac --release 21 --enable-preview -cp junit-platform-console-standalone.jar:out -d out $(find test/java -name '*.java')`
- `java --enable-preview -jar junit-platform-console-standalone.jar --class-path out --scan-class-path`

------
https://chatgpt.com/codex/tasks/task_e_683f9a8157c88321a7b448694bde602d