### PR TITLE
Fix comment whitespace parsing

### DIFF
--- a/src/java/magmac/app/lang/JavaRules.java
+++ b/src/java/magmac/app/lang/JavaRules.java
@@ -182,7 +182,12 @@ public final class JavaRules {
     }
 
     public static Rule createCommentRule() {
-        return new TypeRule("comment", new StringRule("value"));
+        Rule value = new StripRule(new StringRule("value"));
+
+        Rule line = new PrefixRule("//", new SuffixRule(value, "\r\n"));
+        Rule block = new PrefixRule("/*", new SuffixRule(value, "*/"));
+
+        return new TypeRule("comment", new OrRule(Lists.of(line, block)));
     }
 
     private static StripRule createWhitespaceRule() {

--- a/test/java/magmac/app/lang/CommentRuleTest.java
+++ b/test/java/magmac/app/lang/CommentRuleTest.java
@@ -1,0 +1,48 @@
+package magmac.app.lang;
+
+import magmac.app.compile.error.CompileResult;
+import magmac.app.compile.node.Node;
+import magmac.app.compile.rule.Rule;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class CommentRuleTest {
+    private Node lex(Rule rule, String input) {
+        CompileResult<Node> result = rule.lex(input);
+        return result.toResult().match(v -> v, e -> { throw new RuntimeException(e.display()); });
+    }
+
+    @Test
+    public void testLineComment() {
+        Rule rule = JavaRules.createCommentRule();
+        Node node = lex(rule, "//hello\r\n");
+        assertTrue(node.is("comment"));
+        assertEquals("hello", node.findString("value").orElse(null));
+    }
+
+    @Test
+    public void testLineCommentWithWhitespace() {
+        Rule rule = JavaRules.createCommentRule();
+        Node node = lex(rule, "//  hello  \r\n");
+        assertTrue(node.is("comment"));
+        assertEquals("hello", node.findString("value").orElse(null));
+    }
+
+    @Test
+    public void testBlockComment() {
+        Rule rule = JavaRules.createCommentRule();
+        Node node = lex(rule, "/*hi*/");
+        assertTrue(node.is("comment"));
+        assertEquals("hi", node.findString("value").orElse(null));
+    }
+
+    @Test
+    public void testBlockCommentWithWhitespace() {
+        Rule rule = JavaRules.createCommentRule();
+        Node node = lex(rule, "/*  hi  */");
+        assertTrue(node.is("comment"));
+        assertEquals("hi", node.findString("value").orElse(null));
+    }
+}


### PR DESCRIPTION
## Summary
- trim whitespace around comment contents
- extend comment rule unit tests for whitespace cases

## Testing
- `javac --release 21 --enable-preview -d out/test -cp junit-console.jar $(find src/java test/java -name '*.java')`
- `java --enable-preview -cp junit-console.jar:out/test org.junit.platform.console.ConsoleLauncher --scan-classpath`


------
https://chatgpt.com/codex/tasks/task_e_683f99bfe9988321a22e2832f9d44f6e