### PR TITLE
Fix comment whitespace parsing

### DIFF
--- a/src/java/magmac/app/compile/rule/StripSpaceRule.java
+++ b/src/java/magmac/app/compile/rule/StripSpaceRule.java
@@ -1,0 +1,36 @@
+package magmac.app.compile.rule;
+
+import magmac.app.compile.error.CompileResult;
+import magmac.app.compile.node.Node;
+
+/**
+ * Similar to {@link StripRule} but only trims spaces and tabs.
+ * This avoids removing newlines that may be significant for some rules.
+ */
+public record StripSpaceRule(Rule rule) implements Rule {
+    @Override
+    public CompileResult<Node> lex(String input) {
+        return this.rule.lex(stripSpaces(input));
+    }
+
+    @Override
+    public CompileResult<String> generate(Node node) {
+        return this.rule.generate(node);
+    }
+
+    private static String stripSpaces(String input) {
+        int start = 0;
+        int end = input.length();
+        while (start < end && isSpace(input.charAt(start))) {
+            start++;
+        }
+        while (end > start && isSpace(input.charAt(end - 1))) {
+            end--;
+        }
+        return input.substring(start, end);
+    }
+
+    private static boolean isSpace(char c) {
+        return c == ' ' || c == '\t';
+    }
+}

--- a/src/java/magmac/app/lang/JavaRules.java
+++ b/src/java/magmac/app/lang/JavaRules.java
@@ -18,6 +18,7 @@ import magmac.app.compile.rule.PrefixRule;
 import magmac.app.compile.rule.Rule;
 import magmac.app.compile.rule.StringRule;
 import magmac.app.compile.rule.StripRule;
+import magmac.app.compile.rule.StripSpaceRule;
 import magmac.app.compile.rule.SuffixRule;
 import magmac.app.compile.rule.TypeRule;
 import magmac.app.compile.rule.divide.Divider;
@@ -182,7 +183,10 @@ public final class JavaRules {
     }
 
     public static Rule createCommentRule() {
-        return new TypeRule("comment", new StringRule("value"));
+        Rule line = new StripSpaceRule(new PrefixRule("//", new SuffixRule(new StringRule("value"), "\r\n")));
+        Rule block = new StripSpaceRule(new PrefixRule("/*", new SuffixRule(new StringRule("value"), "*/")));
+
+        return new TypeRule("comment", new OrRule(Lists.of(line, block)));
     }
 
     private static StripRule createWhitespaceRule() {

--- a/test/java/magmac/app/lang/CommentRuleTest.java
+++ b/test/java/magmac/app/lang/CommentRuleTest.java
@@ -1,0 +1,64 @@
+package magmac.app.lang;
+
+import magmac.app.compile.error.CompileResult;
+import magmac.app.compile.node.Node;
+import magmac.app.compile.rule.Rule;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class CommentRuleTest {
+    private Node lex(Rule rule, String input) {
+        CompileResult<Node> result = rule.lex(input);
+        return result.toResult().match(v -> v, e -> { throw new RuntimeException(e.display()); });
+    }
+
+    @Test
+    public void testLineComment() {
+        Rule rule = JavaRules.createCommentRule();
+        Node node = lex(rule, "//hello\r\n");
+        assertTrue(node.is("comment"));
+        assertEquals("hello", node.findString("value").orElse(null));
+    }
+
+    @Test
+    public void testLineCommentWithInternalWhitespace() {
+        Rule rule = JavaRules.createCommentRule();
+        Node node = lex(rule, "//  hello  \r\n");
+        assertTrue(node.is("comment"));
+        assertEquals("  hello  ", node.findString("value").orElse(null));
+    }
+
+    @Test
+    public void testLineCommentSurroundedWhitespace() {
+        Rule rule = JavaRules.createCommentRule();
+        Node node = lex(rule, "  //hello\r\n  ");
+        assertTrue(node.is("comment"));
+        assertEquals("hello", node.findString("value").orElse(null));
+    }
+
+    @Test
+    public void testBlockComment() {
+        Rule rule = JavaRules.createCommentRule();
+        Node node = lex(rule, "/*hi*/");
+        assertTrue(node.is("comment"));
+        assertEquals("hi", node.findString("value").orElse(null));
+    }
+
+    @Test
+    public void testBlockCommentWithInternalWhitespace() {
+        Rule rule = JavaRules.createCommentRule();
+        Node node = lex(rule, "/*  hi  */");
+        assertTrue(node.is("comment"));
+        assertEquals("  hi  ", node.findString("value").orElse(null));
+    }
+
+    @Test
+    public void testBlockCommentSurroundedWhitespace() {
+        Rule rule = JavaRules.createCommentRule();
+        Node node = lex(rule, "  /*hi*/  ");
+        assertTrue(node.is("comment"));
+        assertEquals("hi", node.findString("value").orElse(null));
+    }
+}


### PR DESCRIPTION
## Summary
- add StripSpaceRule to trim spaces without stripping line endings
- update comment rule to keep internal whitespace
- expand comment rule tests to check whitespace around markers

## Testing
- `javac --release 21 --enable-preview -d out/test -cp junit-console.jar $(find src/java test/java -name '*.java')`
- `java --enable-preview -cp junit-console.jar:out/test org.junit.platform.console.ConsoleLauncher --scan-classpath`

------
https://chatgpt.com/codex/tasks/task_e_683f99bfe9988321a22e2832f9d44f6e