### PR TITLE
Add TypeMap record for tests

### DIFF
--- a/docs/actual-annotation.md
+++ b/docs/actual-annotation.md
@@ -1,0 +1,6 @@
+# Platform Specific Code with `@Actual`
+
+Some parts of the compiler rely on platform APIs such as Java's file system classes.  When the compiler is translated to TypeScript these implementations are not available.  Classes and static methods annotated with `@Actual` are therefore removed from the generated TypeScript output.  Instance methods ignore the annotation.
+
+This mechanism mirrors Kotlin's expect/actual feature.  The Java sources define the full API but platform specific pieces can be provided separately as `.ts` files when compiling the TypeScript version of the compiler.
+

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -47,5 +47,5 @@ The following features are **not** used:
 
 - reflection or dynamic class loading
 - multi-threading and synchronization primitives
-- Java modules or annotations other than `@Override`
+- Java modules or annotations other than `@Override`. A special `@Actual` annotation marks platform specific code that is omitted from the TypeScript build.
 - advanced I/O or networking APIs

--- a/src/java/magmac/app/annotation/Actual.java
+++ b/src/java/magmac/app/annotation/Actual.java
@@ -1,0 +1,17 @@
+package magmac.app.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks code that has platform specific implementations.
+ * Classes annotated with {@code @Actual} are excluded from the
+ * TypeScript output.  When applied to static methods only the
+ * signature is kept.
+ */
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.SOURCE)
+public @interface Actual {
+}

--- a/src/java/magmac/app/config/TypeMap.java
+++ b/src/java/magmac/app/config/TypeMap.java
@@ -1,0 +1,7 @@
+package magmac.app.config;
+
+import magmac.api.Tuple2;
+import magmac.api.collect.list.List;
+
+public record TypeMap(List<Tuple2<List<String>, String>> types) {
+}

--- a/src/java/magmac/app/io/SafeFiles.java
+++ b/src/java/magmac/app/io/SafeFiles.java
@@ -7,12 +7,14 @@ import magmac.api.collect.list.JVMList;
 import magmac.api.iter.Iter;
 import magmac.api.result.Err;
 import magmac.api.result.Ok;
+import magmac.app.annotation.Actual;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.stream.Collectors;
 
+@Actual
 public final class SafeFiles {
     public static Option<IOException> writeString(Path target, String output) {
         try {

--- a/src/java/magmac/app/io/sources/PathSources.java
+++ b/src/java/magmac/app/io/sources/PathSources.java
@@ -8,6 +8,7 @@ import magmac.api.result.Result;
 import magmac.app.io.IOResult;
 import magmac.app.io.InlineIOResult;
 import magmac.app.io.SafeFiles;
+import magmac.app.annotation.Actual;
 import magmac.app.stage.unit.SimpleUnit;
 import magmac.app.stage.unit.Unit;
 import magmac.app.stage.unit.UnitSet;
@@ -16,6 +17,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+@Actual
 public record PathSources(Path root) implements Sources {
     private static IOResult<Unit<String>> getTuple2IOResult(PathSource source) {
         return source.read().mapValue((String input) -> new SimpleUnit<>(source.computeLocation(), input));

--- a/src/java/magmac/app/io/targets/PathTargets.java
+++ b/src/java/magmac/app/io/targets/PathTargets.java
@@ -4,6 +4,7 @@ import magmac.api.Option;
 import magmac.api.iter.Iters;
 import magmac.app.io.Location;
 import magmac.app.io.SafeFiles;
+import magmac.app.annotation.Actual;
 import magmac.app.stage.unit.Unit;
 import magmac.app.stage.unit.UnitSet;
 
@@ -11,6 +12,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+@Actual
 public record PathTargets(Path root, String extension) implements Targets {
 
     @Override

--- a/test/java/magmac/app/config/ActualAnnotationTest.java
+++ b/test/java/magmac/app/config/ActualAnnotationTest.java
@@ -1,0 +1,30 @@
+package magmac.app.config;
+
+import magmac.api.Some;
+import magmac.api.None;
+import magmac.api.collect.list.Lists;
+import magmac.app.lang.common.Annotation;
+import magmac.app.lang.java.JavaLang;
+import magmac.app.lang.java.JavaMethod;
+import magmac.app.lang.node.Modifier;
+import magmac.app.config.TypeMap;
+import org.junit.jupiter.api.Test;
+
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ActualAnnotationTest {
+    @Test
+    public void staticMethodAnnotatedActualLosesBody() throws Exception {
+        var annotations = Lists.of(new Annotation("Actual"));
+        var modifiers = Lists.of(new Modifier("public"), new Modifier("static"));
+        JavaLang.Definition header = new JavaLang.Definition(new Some<>(annotations), modifiers, "f", new None<>(), new JavaLang.Symbol("void"));
+        JavaMethod method = new JavaMethod(header, Lists.empty(), new Some<>(Lists.of(new JavaLang.Whitespace())));
+
+        TypeMap typeMap = new TypeMap(Lists.empty());
+        var member = JavaTypescriptParser.parseMethod(method, typeMap);
+        assertTrue(member instanceof magmac.app.lang.web.TypescriptLang.TypescriptMethod);
+        var tm = (magmac.app.lang.web.TypescriptLang.TypescriptMethod) member;
+        assertTrue(tm.maybeChildren().isEmpty());
+    }
+}


### PR DESCRIPTION
## Summary
- expose TypeMap so tests can construct it directly
- simplify the ActualAnnotation test by removing reflection
- access TypeMap record methods in parser

## Testing
- `javac --release 21 --enable-preview -d out $(find src/java -name '*.java')`
- `javac --release 21 --enable-preview -cp junit-platform-console-standalone.jar:out -d test-out $(find test/java -name '*.java')`
- `java --enable-preview -jar junit-platform-console-standalone.jar -cp out:test-out --scan-classpath`


------
https://chatgpt.com/codex/tasks/task_e_683f9b8162fc8321b23058dfd85b8931