### PR TITLE
Refactor divide state API

### DIFF
--- a/src/java/magmac/app/compile/rule/divide/DivideState.java
+++ b/src/java/magmac/app/compile/rule/divide/DivideState.java
@@ -26,27 +26,52 @@ public interface DivideState {
 
     Option<DivideState> popAndAppendToOption();
 
-    char peek();
+    /**
+     * Peeks at the next character if available.
+     *
+     * @return the upcoming character or empty when the input is consumed
+     */
+    Option<Character> peek();
 
     boolean inSingle();
 
-    DivideState inSingle(boolean inSingle);
+    /** Begin a single quoted sequence. */
+    DivideState startSingle();
+
+    /** Finish a single quoted sequence. */
+    DivideState endSingle();
 
     boolean inDouble();
 
-    DivideState inDouble(boolean inDouble);
+    /** Begin a double quoted sequence. */
+    DivideState startDouble();
+
+    /** Finish a double quoted sequence. */
+    DivideState endDouble();
 
     boolean inLineComment();
 
-    DivideState inLineComment(boolean inLineComment);
+    /** Start a line comment. */
+    DivideState startLineComment();
+
+    /** End a line comment. */
+    DivideState endLineComment();
 
     boolean inBlockComment();
 
-    DivideState inBlockComment(boolean inBlockComment);
+    /** Start a block comment. */
+    DivideState startBlockComment();
+
+    /** End a block comment. */
+    DivideState endBlockComment();
 
     boolean escape();
 
-    DivideState escape(boolean escape);
+    /** Mark the next character as escaped. */
+    DivideState startEscape();
+
+    /** Cancel escape state. */
+    DivideState endEscape();
 
     char last();
 

--- a/src/java/magmac/app/compile/rule/divide/MutableDivideState.java
+++ b/src/java/magmac/app/compile/rule/divide/MutableDivideState.java
@@ -104,8 +104,11 @@ public class MutableDivideState implements DivideState {
     }
 
     @Override
-    public char peek() {
-        return this.input.charAt(this.index);
+    public Option<Character> peek() {
+        if (this.index < this.input.length()) {
+            return new Some<>(this.input.charAt(this.index));
+        }
+        return new None<>();
     }
 
     @Override
@@ -114,8 +117,14 @@ public class MutableDivideState implements DivideState {
     }
 
     @Override
-    public DivideState inSingle(boolean inSingle) {
-        this.inSingle = inSingle;
+    public DivideState startSingle() {
+        this.inSingle = true;
+        return this;
+    }
+
+    @Override
+    public DivideState endSingle() {
+        this.inSingle = false;
         return this;
     }
 
@@ -125,8 +134,14 @@ public class MutableDivideState implements DivideState {
     }
 
     @Override
-    public DivideState inDouble(boolean inDouble) {
-        this.inDouble = inDouble;
+    public DivideState startDouble() {
+        this.inDouble = true;
+        return this;
+    }
+
+    @Override
+    public DivideState endDouble() {
+        this.inDouble = false;
         return this;
     }
 
@@ -136,8 +151,14 @@ public class MutableDivideState implements DivideState {
     }
 
     @Override
-    public DivideState inLineComment(boolean inLineComment) {
-        this.inLineComment = inLineComment;
+    public DivideState startLineComment() {
+        this.inLineComment = true;
+        return this;
+    }
+
+    @Override
+    public DivideState endLineComment() {
+        this.inLineComment = false;
         return this;
     }
 
@@ -147,8 +168,14 @@ public class MutableDivideState implements DivideState {
     }
 
     @Override
-    public DivideState inBlockComment(boolean inBlockComment) {
-        this.inBlockComment = inBlockComment;
+    public DivideState startBlockComment() {
+        this.inBlockComment = true;
+        return this;
+    }
+
+    @Override
+    public DivideState endBlockComment() {
+        this.inBlockComment = false;
         return this;
     }
 
@@ -158,8 +185,14 @@ public class MutableDivideState implements DivideState {
     }
 
     @Override
-    public DivideState escape(boolean escape) {
-        this.escape = escape;
+    public DivideState startEscape() {
+        this.escape = true;
+        return this;
+    }
+
+    @Override
+    public DivideState endEscape() {
+        this.escape = false;
         return this;
     }
 

--- a/src/java/magmac/app/lang/ValueFolder.java
+++ b/src/java/magmac/app/lang/ValueFolder.java
@@ -12,7 +12,7 @@ public class ValueFolder implements Folder {
 
         var appended = state.append(c);
         if ('-' == c) {
-            if ('>' == state.peek()) {
+            if (state.peek().filter(n -> n == '>').isPresent()) {
                 return state.popAndAppendToOption().orElse(state);
             }
         }


### PR DESCRIPTION
## Summary
- return `Option` from `peek` in `DivideState`
- replace boolean setters with start/end methods
- update `MutableDivideState` implementation
- add helper quote handlers in `DecoratedFolder`
- adjust `ValueFolder` for new `peek`

## Testing
- `javac --release 21 --enable-preview -d out $(find src/java -name '*.java')`
- `curl -L -o junit-platform-console-standalone.jar https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/1.10.1/junit-platform-console-standalone-1.10.1.jar`
- `javac --release 21 --enable-preview -cp junit-platform-console-standalone.jar:out -d out $(find test/java -name '*.java')`
- `java --enable-preview -jar junit-platform-console-standalone.jar --class-path out --scan-class-path`

------
https://chatgpt.com/codex/tasks/task_e_683fa0e0dba083218e22dc8a0eed6dae