### PR TITLE
Add primitive type mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ java -cp out magmac.Main
 
 This will scan the sources, run the compiler pipeline and write the generated outputs to the directories configured by each `TargetPlatform` (for example `diagrams` for PlantUML files and `src/web` for TypeScript files).
 
+Primitive Java types are translated to their TypeScript equivalents. Numeric primitives
+(`byte`, `short`, `int`, `long`, `float`, `double`) become `number`, `boolean` stays
+`boolean` and `char` or `String` are emitted as `string`.
+
 ## Repository Layout
 
 - `src/java` – Java source code for the compiler implementation

--- a/src/java/magmac/app/config/JavaTypescriptParser.java
+++ b/src/java/magmac/app/config/JavaTypescriptParser.java
@@ -335,7 +335,12 @@ class JavaTypescriptParser implements Parser<JavaLang.Root, TypescriptLang.Types
     }
 
     private static Symbol parseSymbol(JavaLang.Symbol symbol) {
-        return new Symbol(symbol.value());
+        return switch (symbol.value()) {
+            case "byte", "short", "int", "long", "float", "double" -> new Symbol("number");
+            case "boolean" -> new Symbol("boolean");
+            case "char", "String" -> new Symbol("string");
+            default -> new Symbol(symbol.value());
+        };
     }
 
     private static Symbol parseQualifiedType(JavaLang.Qualified qualified) {


### PR DESCRIPTION
## Summary
- map primitive Java symbols to the correct TypeScript primitives
- document how primitive types are mapped

## Testing
- `npm test` *(fails: Error: no test specified)*
- `javac --release 21 --enable-preview -d out $(find src/java -name '*.java')`

------
https://chatgpt.com/codex/tasks/task_e_683fa40675608321bcf5f92c45fbde44