### PR TITLE
Remove npm test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,7 @@
   "main": "./src/index.ts",
   "scripts": {
     "start": "ts-node ./src/web/magmac/Main.ts",
-    "dev": "nodemon",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "dev": "nodemon"
   },
   "devDependencies": {
     "@types/node": "^22.15.23",


### PR DESCRIPTION
## Summary
- clean up npm scripts by removing the placeholder `test` task

## Testing
- `javac --release 21 --enable-preview -d out $(find src/java -name '*.java')`
- `curl -L -o junit-platform-console-standalone.jar https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/1.10.1/junit-platform-console-standalone.jar` *(fails: zip END header not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fb353628483218d1c9f5a3e6b2922