### PR TITLE
Add Javadoc for interfaces

### DIFF
--- a/src/java/magmac/app/Application.java
+++ b/src/java/magmac/app/Application.java
@@ -5,6 +5,15 @@ import magmac.api.error.Error;
 import magmac.app.lang.java.JavaLang;
 import magmac.app.stage.unit.UnitSet;
 
+/**
+ * Entry point for loading source units and persisting compiler results.
+ */
 public interface Application {
+    /**
+     * Parses the supplied source units and stores the outputs.
+     *
+     * @param units compilation units describing the program sources
+     * @return an {@link Option} containing an error when parsing failed
+     */
     Option<Error> parseAndStore(UnitSet<JavaLang.Root> units);
 }

--- a/src/java/magmac/app/compile/Compiler.java
+++ b/src/java/magmac/app/compile/Compiler.java
@@ -4,6 +4,15 @@ import magmac.app.compile.error.CompileResult;
 import magmac.app.lang.java.JavaLang;
 import magmac.app.stage.unit.UnitSet;
 
+/**
+ * Front end of the compiler performing parsing and code generation.
+ */
 public interface Compiler {
+    /**
+     * Parses and generates outputs for the provided units.
+     *
+     * @param units program sources to compile
+     * @return a compilation result containing generated outputs or errors
+     */
     CompileResult<UnitSet<String>> parseAndGenerate(UnitSet<JavaLang.Root> units);
 }

--- a/src/java/magmac/app/compile/error/CompileResult.java
+++ b/src/java/magmac/app/compile/error/CompileResult.java
@@ -8,18 +8,44 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+/**
+ * Outcome of a compilation step which may hold a value or a {@link CompileError}.
+ *
+ * @param <T> type of the successful value
+ */
 public interface CompileResult<T> {
+    /**
+     * Merges this result with another result using a value merger.
+     */
     CompileResult<T> merge(Supplier<CompileResult<T>> other, BiFunction<T, T, T> merger);
 
+    /**
+     * Maps the successful value using {@code mapper}.
+     */
     <R> CompileResult<R> mapValue(Function<T, R> mapper);
 
+    /**
+     * Applies one of the functions depending on success or error.
+     */
     <R> R match(Function<T, R> whenOk, Function<CompileError, R> whenErr);
 
+    /**
+     * Maps the contained error using {@code mapper}.
+     */
     CompileResult<T> mapErr(Function<CompileError, CompileError> mapper);
 
+    /**
+     * Maps to another result and flattens the output.
+     */
     <R> CompileResult<R> flatMapValue(Function<T, CompileResult<R>> mapper);
 
+    /**
+     * Combines this result with the supplied one.
+     */
     <R> CompileResult<Tuple2<T, R>> and(Supplier<CompileResult<R>> supplier);
 
+    /**
+     * Converts this compile result to a generic {@link Result}.
+     */
     Result<T, CompileError> toResult();
 }

--- a/src/java/magmac/app/compile/error/context/Context.java
+++ b/src/java/magmac/app/compile/error/context/Context.java
@@ -1,5 +1,11 @@
 package magmac.app.compile.error.context;
 
+/**
+ * Additional information attached to a {@code CompileError} for context.
+ */
 public interface Context {
+    /**
+     * Formats this context as a human readable string.
+     */
     String display();
 }

--- a/src/java/magmac/app/compile/error/error/CompileError.java
+++ b/src/java/magmac/app/compile/error/error/CompileError.java
@@ -3,8 +3,17 @@ package magmac.app.compile.error.error;
 import magmac.api.collect.list.List;
 import magmac.api.error.Error;
 
+/**
+ * Represents a problem encountered during compilation.
+ */
 public interface CompileError extends Error {
+    /**
+     * Computes the maximum indentation depth when formatting.
+     */
     int computeMaxDepth();
 
+    /**
+     * Formats this error with an indentation depth and index stack.
+     */
     String format(int depth, List<Integer> indices);
 }

--- a/src/java/magmac/app/compile/node/CompoundDestructor.java
+++ b/src/java/magmac/app/compile/node/CompoundDestructor.java
@@ -7,14 +7,32 @@ import magmac.app.compile.error.CompileResult;
 
 import java.util.function.Function;
 
+/**
+ * Helper used to destructure nested {@link Node} structures step by step.
+ */
 public interface CompoundDestructor<T> {
+    /**
+     * Completes the destruction producing a value.
+     */
     <R> CompileResult<R> complete(Function<T, R> mapper);
 
+    /**
+     * Extracts a list under {@code key} using the given deserializer.
+     */
     <R> CompoundDestructor<Tuple2<T, List<R>>> withNodeList(String key, Function<Node, CompileResult<R>> deserializer);
 
+    /**
+     * Extracts a child node under {@code key} using the given deserializer.
+     */
     <R> CompoundDestructor<Tuple2<T, R>> withNode(String key, Function<Node, CompileResult<R>> deserializer);
 
+    /**
+     * Optionally extracts a child node when present.
+     */
     <R> CompoundDestructor<Tuple2<T, Option<R>>> withNodeOptionally(String key, Function<Node, CompileResult<R>> deserializer);
 
+    /**
+     * Optionally extracts a list when present.
+     */
     <R> CompoundDestructor<Tuple2<T, Option<List<R>>>> withNodeListOptionally(String key, Function<Node, CompileResult<R>> deserializer);
 }

--- a/src/java/magmac/app/compile/node/InitialDestructor.java
+++ b/src/java/magmac/app/compile/node/InitialDestructor.java
@@ -7,12 +7,27 @@ import magmac.app.lang.node.Deserializer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+/**
+ * Starting point for destructuring a {@link Node}.
+ */
 public interface InitialDestructor {
+    /**
+     * Reads a list under {@code key} using the provided deserializer.
+     */
     <T> CompoundDestructor<List<T>> withNodeList(String key, Deserializer<T> deserializer);
 
+    /**
+     * Reads a plain string value under {@code key}.
+     */
     CompoundDestructor<String> withString(String key);
 
+    /**
+     * Reads a child node under {@code key} using the supplied deserializer.
+     */
     <T> CompoundDestructor<T> withNode(String key, Function<Node, CompileResult<T>> deserializer);
 
+    /**
+     * Finishes building the value using the gathered pieces.
+     */
     <T> CompileResult<T> complete(Supplier<T> supplier);
 }

--- a/src/java/magmac/app/compile/node/Node.java
+++ b/src/java/magmac/app/compile/node/Node.java
@@ -9,6 +9,9 @@ import magmac.app.lang.Serializable;
 
 import java.util.function.Function;
 
+/**
+ * Generic tree node used by the compiler front end.
+ */
 public interface Node {
     CompileResult<NodeList> findNodeListOrError(String key);
 

--- a/src/java/magmac/app/compile/node/NodeList.java
+++ b/src/java/magmac/app/compile/node/NodeList.java
@@ -6,6 +6,9 @@ import magmac.app.compile.error.CompileResult;
 
 import java.util.function.Function;
 
+/**
+ * Immutable collection of {@link Node} values.
+ */
 public interface NodeList {
     Iter<Node> iter();
 

--- a/src/java/magmac/app/compile/rule/Rule.java
+++ b/src/java/magmac/app/compile/rule/Rule.java
@@ -3,6 +3,9 @@ package magmac.app.compile.rule;
 import magmac.app.compile.error.CompileResult;
 import magmac.app.compile.node.Node;
 
+/**
+ * Describes how to lex source text and generate output for a language.
+ */
 public interface Rule {
     CompileResult<Node> lex(String input);
 

--- a/src/java/magmac/app/compile/rule/Splitter.java
+++ b/src/java/magmac/app/compile/rule/Splitter.java
@@ -3,6 +3,9 @@ package magmac.app.compile.rule;
 import magmac.api.Option;
 import magmac.api.Tuple2;
 
+/**
+ * Divides an input string into two parts based on some criteria.
+ */
 public interface Splitter {
     Option<Tuple2<String, String>> split(String input);
 

--- a/src/java/magmac/app/compile/rule/divide/DivideState.java
+++ b/src/java/magmac/app/compile/rule/divide/DivideState.java
@@ -5,6 +5,9 @@ import magmac.api.Tuple2;
 import magmac.api.Option;
 import magmac.api.iter.Iter;
 
+/**
+ * Mutable state machine used by a {@link Divider} implementation.
+ */
 public interface DivideState {
     DivideState append(char c);
 

--- a/src/java/magmac/app/compile/rule/divide/Divider.java
+++ b/src/java/magmac/app/compile/rule/divide/Divider.java
@@ -2,6 +2,9 @@ package magmac.app.compile.rule.divide;
 
 import magmac.api.iter.Iter;
 
+/**
+ * Splits an input string into subsections using a {@link DivideState}.
+ */
 public interface Divider {
     Iter<String> divide(String input);
 

--- a/src/java/magmac/app/compile/rule/filter/Filter.java
+++ b/src/java/magmac/app/compile/rule/filter/Filter.java
@@ -1,5 +1,8 @@
 package magmac.app.compile.rule.filter;
 
+/**
+ * Predicate used by a lexer to ignore or accept tokens.
+ */
 public interface Filter {
     boolean test(String input);
 

--- a/src/java/magmac/app/compile/rule/fold/Folder.java
+++ b/src/java/magmac/app/compile/rule/fold/Folder.java
@@ -2,6 +2,9 @@ package magmac.app.compile.rule.fold;
 
 import magmac.app.compile.rule.divide.DivideState;
 
+/**
+ * Consumes characters one by one to build a {@link DivideState}.
+ */
 public interface Folder {
     DivideState fold(DivideState state, char c);
 

--- a/src/java/magmac/app/compile/rule/locate/Locator.java
+++ b/src/java/magmac/app/compile/rule/locate/Locator.java
@@ -2,6 +2,9 @@ package magmac.app.compile.rule.locate;
 
 import magmac.api.Option;
 
+/**
+ * Finds positions within a string during lexing.
+ */
 public interface Locator {
     Option<Integer> locate(String input, String infix);
 }

--- a/src/java/magmac/app/config/TargetPlatform.java
+++ b/src/java/magmac/app/config/TargetPlatform.java
@@ -6,6 +6,9 @@ import magmac.app.compile.rule.Rule;
 
 import java.nio.file.Path;
 
+/**
+ * Creates the components for generating output for a specific target.
+ */
 public interface TargetPlatform {
     Application createApplication();
 

--- a/src/java/magmac/app/io/IOResult.java
+++ b/src/java/magmac/app/io/IOResult.java
@@ -5,6 +5,9 @@ import magmac.api.result.Result;
 import java.io.IOException;
 import java.util.function.Function;
 
+/**
+ * IO operation that may succeed with a value or fail with an {@link IOException}.
+ */
 public interface IOResult<T> {
     <R> IOResult<R> mapValue(Function<T, R> mapper);
 

--- a/src/java/magmac/app/io/sources/Sources.java
+++ b/src/java/magmac/app/io/sources/Sources.java
@@ -4,6 +4,9 @@ import magmac.app.io.IOResult;
 
 import magmac.app.stage.unit.UnitSet;
 
+/**
+ * Abstraction for retrieving source code units.
+ */
 public interface Sources {
     IOResult<UnitSet<String>> readAll();
 }

--- a/src/java/magmac/app/io/targets/Targets.java
+++ b/src/java/magmac/app/io/targets/Targets.java
@@ -5,6 +5,9 @@ import java.io.IOException;
 import magmac.api.Option;
 import magmac.app.stage.unit.UnitSet;
 
+/**
+ * Destination for compiler output such as files or network locations.
+ */
 public interface Targets {
     Option<IOException> writeAll(UnitSet<String> outputs);
 }

--- a/src/java/magmac/app/lang/Deserializer.java
+++ b/src/java/magmac/app/lang/Deserializer.java
@@ -4,6 +4,9 @@ import magmac.api.Option;
 import magmac.app.compile.error.CompileResult;
 import magmac.app.compile.node.Node;
 
+/**
+ * Converts a raw {@link Node} into a typed value.
+ */
 public interface Deserializer<T> {
     Option<CompileResult<T>> deserialize(Node node);
 }

--- a/src/java/magmac/app/lang/LazyRule.java
+++ b/src/java/magmac/app/lang/LazyRule.java
@@ -2,6 +2,9 @@ package magmac.app.lang;
 
 import magmac.app.compile.rule.Rule;
 
+/**
+ * Proxy rule that can be assigned later to break dependency cycles.
+ */
 public interface LazyRule extends Rule {
     LazyRule set(Rule rule);
 }

--- a/src/java/magmac/app/lang/Serializable.java
+++ b/src/java/magmac/app/lang/Serializable.java
@@ -2,6 +2,12 @@ package magmac.app.lang;
 
 import magmac.app.compile.node.Node;
 
+/**
+ * Indicates that a value can be converted into a {@link Node} tree.
+ */
 public interface Serializable {
+    /**
+     * Serializes this value into its node representation.
+     */
     Node serialize();
 }

--- a/src/java/magmac/app/lang/java/JavaLang.java
+++ b/src/java/magmac/app/lang/java/JavaLang.java
@@ -39,33 +39,45 @@ import magmac.app.lang.node.TypedDeserializer;
 import magmac.app.lang.web.TypescriptLang;
 
 public class JavaLang {
+    /** Argument to a Java callable or operation. */
     public sealed interface JavaArgument permits Value, Whitespace, Comment {
     }
 
+    /** Expression that can be invoked like a function. */
     public sealed interface JavaCaller permits Construction, Value {
     }
 
+    /** Value that can appear on the left side of an assignment. */
     public sealed interface Assignable {
     }
 
+    /**
+     * Any Java expression value.
+     */
     public sealed interface Value extends JavaCaller, JavaArgument, Assignable permits Access, Char, Index, InstanceOf, Invokable, Lambda, Not, Number, StringValue, SwitchNode, Symbol, operation {
     }
 
+    /** Header introducing a conditional or try block. */
     public sealed interface BlockHeader permits Catch, Conditional, Else, Try {
     }
 
+    /** Base element used by complex type expressions. */
     public sealed interface Base extends Serializable permits Qualified, Symbol {
     }
 
+    /** Contents of a lambda expression body. */
     public interface JavaLambdaContent {
     }
 
+    /** Type appearing in Java source code. */
     public sealed interface JavaType permits JavaArrayType, Symbol, JavaTemplateType, Qualified, JavaVariadicType {
     }
 
+    /** Parameter list header of a lambda expression. */
     public interface JavaLambdaHeader {
     }
 
+    /** Single parameter in a lambda expression. */
     public interface JavaLambdaParameter {
     }
 

--- a/src/java/magmac/app/lang/web/Caller.java
+++ b/src/java/magmac/app/lang/web/Caller.java
@@ -2,5 +2,8 @@ package magmac.app.lang.web;
 
 import magmac.app.lang.Serializable;
 
+/**
+ * JavaScript value that can be invoked as a function.
+ */
 public interface Caller extends Serializable {
 }

--- a/src/java/magmac/app/lang/web/TypescriptLang.java
+++ b/src/java/magmac/app/lang/web/TypescriptLang.java
@@ -21,35 +21,48 @@ import magmac.app.lang.node.Segment;
 import magmac.app.lang.node.StructureValue;
 
 public final class TypescriptLang {
+    /** Argument to a TypeScript function call. */
     public interface Argument extends Serializable {
     }
 
+    /** Parameter definition inside a function header. */
     public interface TypeScriptParameter extends Serializable {
     }
 
+    /** Header introducing a block of statements. */
     public interface TypescriptBlockHeader extends Serializable {
     }
 
+    /** Member that can appear inside a structure body. */
     public interface TypescriptStructureMember extends Serializable {
     }
 
+    /** Signature of a TypeScript method. */
     public interface TypeScriptMethodHeader extends Serializable {
     }
 
+    /** A concrete type node. */
     public interface Type extends Serializable {
     }
 
+    /** Segment that can occur at the top level of a source file. */
     public interface TypeScriptRootSegment extends Serializable {
     }
 
+    /** Segment that forms part of a function. */
     public interface FunctionSegment extends Serializable {
+        /**
+         * Value contained within a function segment.
+         */
         interface Value extends Serializable {
         }
     }
 
+    /** Expression value within the TypeScript language. */
     public interface Value extends Caller, Argument, Assignable {
     }
 
+    /** Something that can appear on the left hand side of an assignment. */
     public interface Assignable extends Serializable {
     }
 

--- a/src/java/magmac/app/stage/Passer.java
+++ b/src/java/magmac/app/stage/Passer.java
@@ -4,6 +4,12 @@ import magmac.app.compile.node.Node;
 import magmac.app.stage.parse.ParseState;
 import magmac.app.stage.result.ParseResult;
 
+/**
+ * Performs a single pass over a parse tree.
+ */
 public interface Passer {
+    /**
+     * Processes the given {@code node} within the provided parse state.
+     */
     ParseResult pass(ParseState state, Node node);
 }

--- a/src/java/magmac/app/stage/Stage.java
+++ b/src/java/magmac/app/stage/Stage.java
@@ -2,6 +2,12 @@ package magmac.app.stage;
 
 import magmac.app.compile.error.CompileResult;
 
+/**
+ * One step in the compiler pipeline transforming a value of type {@code T} into {@code R}.
+ */
 public interface Stage<T, R> {
+    /**
+     * Executes this stage using {@code initial} as input.
+     */
     CompileResult<R> apply(T initial);
 }

--- a/src/java/magmac/app/stage/after/AfterAll.java
+++ b/src/java/magmac/app/stage/after/AfterAll.java
@@ -3,6 +3,12 @@ package magmac.app.stage.after;
 import magmac.app.compile.node.Node;
 import magmac.app.stage.unit.UnitSet;
 
+/**
+ * Hook invoked once code generation is complete.
+ */
 public interface AfterAll {
+    /**
+     * Runs after all compilation units have been generated.
+     */
     UnitSet<Node> afterAll(UnitSet<Node> roots);
 }

--- a/src/java/magmac/app/stage/generate/Generator.java
+++ b/src/java/magmac/app/stage/generate/Generator.java
@@ -4,5 +4,8 @@ import magmac.app.compile.node.Node;
 import magmac.app.stage.unit.UnitSet;
 import magmac.app.stage.Stage;
 
+/**
+ * Stage producing textual output from AST nodes.
+ */
 public interface Generator extends Stage<UnitSet<Node>, UnitSet<String>> {
 }

--- a/src/java/magmac/app/stage/lexer/Lexer.java
+++ b/src/java/magmac/app/stage/lexer/Lexer.java
@@ -4,5 +4,8 @@ import magmac.app.compile.node.Node;
 import magmac.app.stage.unit.UnitSet;
 import magmac.app.stage.Stage;
 
+/**
+ * Stage that converts raw text into a tree of {@link Node}s.
+ */
 public interface Lexer extends Stage<UnitSet<String>, UnitSet<Node>> {
 }

--- a/src/java/magmac/app/stage/parse/ParseState.java
+++ b/src/java/magmac/app/stage/parse/ParseState.java
@@ -2,6 +2,12 @@ package magmac.app.stage.parse;
 
 import magmac.app.io.Location;
 
+/**
+ * Information tracked while parsing source units.
+ */
 public interface ParseState {
+    /**
+     * Returns the current source location.
+     */
     Location findLocation();
 }

--- a/src/java/magmac/app/stage/parse/Parser.java
+++ b/src/java/magmac/app/stage/parse/Parser.java
@@ -3,5 +3,8 @@ package magmac.app.stage.parse;
 import magmac.app.stage.unit.UnitSet;
 import magmac.app.stage.Stage;
 
+/**
+ * Stage that turns tokens into typed AST nodes.
+ */
 public interface Parser<T, R> extends Stage<UnitSet<T>, UnitSet<R>> {
 }

--- a/src/java/magmac/app/stage/result/ParseResult.java
+++ b/src/java/magmac/app/stage/result/ParseResult.java
@@ -6,6 +6,12 @@ import magmac.app.stage.unit.ParseUnit;
 
 import java.util.function.Supplier;
 
+/**
+ * Result of a single pass through the parser.
+ */
 public interface ParseResult {
+    /**
+     * Returns this result or falls back to {@code other} when empty.
+     */
     CompileResult<ParseUnit<Node>> orElseGet(Supplier<ParseUnit<Node>> other);
 }

--- a/src/java/magmac/app/stage/unit/ParseUnit.java
+++ b/src/java/magmac/app/stage/unit/ParseUnit.java
@@ -5,6 +5,9 @@ import magmac.app.stage.parse.ParseState;
 
 import java.util.function.BiFunction;
 
+/**
+ * Compilation unit produced by the parser.
+ */
 public interface ParseUnit<T> {
     Unit<T> toLocationUnit();
 

--- a/src/java/magmac/app/stage/unit/Unit.java
+++ b/src/java/magmac/app/stage/unit/Unit.java
@@ -6,6 +6,9 @@ import magmac.app.io.Location;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
+/**
+ * A single compilation unit paired with its source location.
+ */
 public interface Unit<T> {
     <R> R destruct(BiFunction<Location, T, R> merger);
 

--- a/src/java/magmac/app/stage/unit/UnitSet.java
+++ b/src/java/magmac/app/stage/unit/UnitSet.java
@@ -5,6 +5,9 @@ import magmac.app.compile.error.CompileResult;
 
 import java.util.function.Function;
 
+/**
+ * Collection of compilation units that can be processed together.
+ */
 public interface UnitSet<T> {
     Iter<T> iterValues();
 


### PR DESCRIPTION
## Summary
- document `Application` interface
- add missing Javadoc to compiler interfaces and stages
- document nested TypeScript and Java interfaces

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_683fb7c94bd0832186396537c8a2ae96