### PR TITLE
Refactor parser to reduce allocations and add tests

### DIFF
--- a/test/java/magmac/app/config/RootParseTest.java
+++ b/test/java/magmac/app/config/RootParseTest.java
@@ -1,0 +1,43 @@
+package magmac.app.config;
+
+import magmac.api.collect.list.List;
+import magmac.api.collect.list.Lists;
+import magmac.app.compile.error.CompileResult;
+import magmac.app.compile.node.Node;
+import magmac.app.compile.rule.Rule;
+import magmac.app.io.Location;
+import magmac.app.lang.JavaRules;
+import magmac.app.lang.java.JavaDeserializers;
+import magmac.app.lang.java.JavaLang;
+import magmac.app.stage.unit.MapUnitSet;
+import magmac.app.stage.unit.SimpleUnit;
+import magmac.app.stage.unit.UnitSet;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class RootParseTest {
+    private JavaLang.Root parse(String input) {
+        Rule rule = JavaRules.createRule();
+        CompileResult<Node> result = rule.lex(input);
+        Node node = result.toResult().match(v -> v, e -> { throw new RuntimeException(e.display()); });
+        return JavaLang.Root.getChildren(node, JavaDeserializers::deserializeRootSegment)
+                .toResult().match(v -> v, e -> { throw new RuntimeException(e.display()); });
+    }
+
+    @Test
+    public void multipleStructuresParsed() {
+        var root = parse("class A {}\nclass B {}\n");
+        var loc = new Location(Lists.of("test"), "File");
+        UnitSet<JavaLang.Root> set = new MapUnitSet<JavaLang.Root>().add(new SimpleUnit<>(loc, root));
+
+        var parser = new JavaTypescriptParser();
+        var result = parser.apply(set);
+        var tsSet = result.toResult().match(v -> v, e -> { throw new RuntimeException(e.display()); });
+        var tsRoot = tsSet.iter().next().map(u -> u.destruct((l, r) -> r)).orElseGet(() -> { throw new RuntimeException(); });
+
+        List<magmac.app.lang.web.TypescriptLang.TypeScriptRootSegment> children = tsRoot.children();
+        int count = children.iter().fold(0, (c, seg) -> seg instanceof magmac.app.lang.web.TypescriptLang.StructureNode ? c + 1 : c);
+        assertEquals(2, count);
+    }
+}

--- a/test/java/magmac/app/config/VariadicParameterTest.java
+++ b/test/java/magmac/app/config/VariadicParameterTest.java
@@ -1,0 +1,38 @@
+package magmac.app.config;
+
+import magmac.api.None;
+import magmac.api.collect.list.Lists;
+import magmac.app.io.Location;
+import magmac.app.lang.java.JavaLang;
+import magmac.app.lang.java.JavaMethod;
+import magmac.app.lang.node.Modifier;
+import magmac.app.lang.web.TypescriptLang;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class VariadicParameterTest {
+    @Test
+    public void variadicParameterBecomesArray() {
+        var param = new JavaLang.Definition(new None<>(), Lists.empty(), "a", new None<>(),
+                new JavaLang.JavaVariadicType(new JavaLang.Symbol("int")));
+        var header = new JavaLang.Definition(new None<>(), Lists.empty(), "f", new None<>(),
+                new JavaLang.Symbol("void"));
+        var method = new JavaMethod(header, Lists.of(param), new None<>());
+
+        var loc = new Location(Lists.of("test"), "A");
+        var state = new CompileState(Lists.empty(), loc);
+        JavaTypescriptParser.parseMethod(method, state)
+                .toResult()
+                .consume(m -> {
+                    assertTrue(m instanceof TypescriptLang.TypescriptMethod);
+                    var tsMethod = (TypescriptLang.TypescriptMethod) m;
+                    var first = tsMethod.header().parameters().get(0);
+                    assertTrue(first instanceof TypescriptLang.Definition);
+                    var def = (TypescriptLang.Definition) first;
+                    assertEquals("...a", def.name());
+                    assertTrue(def.type() instanceof TypescriptLang.ArrayType);
+                }, err -> Assertions.fail(err.display()));
+    }
+}


### PR DESCRIPTION
## Summary
- optimize `JavaTypescriptParser.parseRoot` to avoid large intermediate lists
- extract import generation helper
- add tests covering variadic parameters and root parsing

## Testing
- `javac --release 21 --enable-preview -d out $(find src/java -name '*.java')`
- `javac --release 21 --enable-preview -cp junit-platform-console-standalone.jar:out -d out $(find test/java -name '*.java')`
- `java --enable-preview -jar junit-platform-console-standalone.jar --class-path out --scan-class-path`


------
https://chatgpt.com/codex/tasks/task_e_683fb8e0f87883219d12266f393ae506