### PR TITLE
Add project roadmap and missing TypeScript features

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Primitive Java types are translated to their TypeScript equivalents. Numeric pri
 See [`docs/architecture.md`](docs/architecture.md) for an overview of how the compiler is structured.
 For details on how the PlantUML class diagram is generated see [`docs/diagram-generation.md`](docs/diagram-generation.md).
 The inspection report produced by IntelliJ is summarised in [`docs/inspection/tasks.md`](docs/inspection/tasks.md).
+For a high level roadmap and a list of missing Java→TypeScript features see [`docs/roadmap.md`](docs/roadmap.md).
 
 Instance fields in the Java sources are always accessed using `this`. Java does
 not require it, but TypeScript does, and using the same convention avoids an

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,42 @@
+# Project Roadmap
+
+This document summarises the long‑term goals of the Magmac compiler and lists the main gaps in the current Java→TypeScript translation.
+
+## Primary Goal
+
+The Magmac compiler is designed to become a **bootstrapped, self‑hosting compiler**. The current implementation is written in Java and produces TypeScript so that the compiler can run inside JavaScript environments. Once the TypeScript version is stable, the Java parser will be replaced with one for the Magma language itself. After the compiler can compile its own sources from Magma to TypeScript, new back‑ends will target C via Clang and later LLVM.
+
+## Roadmap Overview
+
+1. **Stabilise the Java implementation** and refine the TypeScript pipeline.
+2. **Produce a functional TypeScript build** of the compiler.
+3. **Introduce a Magma front end** to achieve self‑hosting.
+4. **Add additional back ends**, starting with C/LLVM.
+5. **Refactor and document** the codebase continually.
+
+## Missing Features for Java → TypeScript Conversion
+
+The TypeScript pipeline is incomplete and several constructs are emitted as placeholders. Notable gaps include:
+
+- **Lambda, `switch` and `instanceof` expressions** are mapped to `0` during conversion. The relevant code can be seen in `JavaTypescriptParser`:
+  ```java
+  case JavaLang.Lambda javaLambda -> new TypescriptLang.Number("0");
+  case JavaLang.SwitchNode javaSwitchNode -> new TypescriptLang.Number("0");
+  case JavaLang.InstanceOf instanceOf -> new TypescriptLang.Number("0");
+  ```
+- **Block headers** such as `if`, `for` or `while` are not parsed. The parser always emits `if (true)`:
+  ```java
+  private static TypescriptLang.TypescriptBlockHeader parseHeader(JavaLang.BlockHeader header) {
+      return new TypescriptLang.TypescriptConditional(ConditionalType.If, new Symbol("true"));
+  }
+  ```
+- **`case` statements** inside `switch` blocks are ignored and become whitespace:
+  ```java
+  case JavaLang.Case caseNode -> new TypescriptLang.Whitespace();
+  ```
+- **Variadic types and some complex type constructs** are replaced with the symbol `?`:
+  ```java
+  case JavaLang.JavaVariadicType type -> CompileResults.Ok(new Symbol("?"));
+  ```
+
+Because of these missing features the generated TypeScript currently does not compile, and the CI workflow skips the `tsc` step. Filling in these gaps is required before the compiler can bootstrap itself.


### PR DESCRIPTION
## Summary
- document long-term goals and missing features in `docs/roadmap.md`
- link the roadmap from README

## Testing
- `javac --release 21 --enable-preview -d out $(find src/java -name '*.java')`
- `javac --release 21 --enable-preview -cp junit-platform-console-standalone.jar:out -d out $(find test/java -name '*.java')`
- `java --enable-preview -jar junit-platform-console-standalone.jar --class-path out --scan-class-path`


------
https://chatgpt.com/codex/tasks/task_e_683fba08cc008321b08de9950ca7fc02