### PR TITLE
Add package-info files

### DIFF
--- a/src/java/jvm/io/package-info.java
+++ b/src/java/jvm/io/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * I/O utilities for running on the JVM.
+ *
+ * <p>
+ * Recommendation: Small leaf package; no immediate need to break up or merge.
+ * </p>
+ */
+package jvm.io;

--- a/src/java/jvm/package-info.java
+++ b/src/java/jvm/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * JVM utilities used during compilation.
+ *
+ * <p>
+ * Recommendation: Keep this package as a namespace with focused subpackages.
+ * </p>
+ */
+package jvm;

--- a/src/java/magmac/api/collect/list/package-info.java
+++ b/src/java/magmac/api/collect/list/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * List collectors and wrappers.
+ *
+ * <p>
+ * Recommendation: Small leaf package; no immediate need to break up or merge.
+ * </p>
+ */
+package magmac.api.collect.list;

--- a/src/java/magmac/api/collect/map/package-info.java
+++ b/src/java/magmac/api/collect/map/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Map collectors and wrappers.
+ *
+ * <p>
+ * Recommendation: Small leaf package; no immediate need to break up or merge.
+ * </p>
+ */
+package magmac.api.collect.map;

--- a/src/java/magmac/api/collect/package-info.java
+++ b/src/java/magmac/api/collect/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Collectors for building data structures.
+ *
+ * <p>
+ * Recommendation: Keep this package as a namespace with focused subpackages.
+ * </p>
+ */
+package magmac.api.collect;

--- a/src/java/magmac/api/error/package-info.java
+++ b/src/java/magmac/api/error/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Simple error abstraction.
+ *
+ * <p>
+ * Recommendation: Small leaf package; no immediate need to break up or merge.
+ * </p>
+ */
+package magmac.api.error;

--- a/src/java/magmac/api/head/package-info.java
+++ b/src/java/magmac/api/head/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Lazy stream head utilities.
+ *
+ * <p>
+ * Recommendation: Consider splitting into subpackages if more classes are added.
+ * </p>
+ */
+package magmac.api.head;

--- a/src/java/magmac/api/iter/collect/package-info.java
+++ b/src/java/magmac/api/iter/collect/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Helpers to collect iterator values.
+ *
+ * <p>
+ * Recommendation: Small leaf package; no immediate need to break up or merge.
+ * </p>
+ */
+package magmac.api.iter.collect;

--- a/src/java/magmac/api/iter/package-info.java
+++ b/src/java/magmac/api/iter/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Iterators used in functional APIs.
+ *
+ * <p>
+ * Recommendation: Keep this package as a namespace with focused subpackages.
+ * </p>
+ */
+package magmac.api.iter;

--- a/src/java/magmac/api/result/package-info.java
+++ b/src/java/magmac/api/result/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Result data type used for pipeline processing.
+ *
+ * <p>
+ * Recommendation: Small leaf package; no immediate need to break up or merge.
+ * </p>
+ */
+package magmac.api.result;

--- a/src/java/magmac/app/annotation/package-info.java
+++ b/src/java/magmac/app/annotation/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Annotations used by the compiler.
+ *
+ * <p>
+ * Recommendation: Small leaf package; no immediate need to break up or merge.
+ * </p>
+ */
+package magmac.app.annotation;

--- a/src/java/magmac/app/compile/error/context/package-info.java
+++ b/src/java/magmac/app/compile/error/context/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Context information for compile errors.
+ *
+ * <p>
+ * Recommendation: Small leaf package; no immediate need to break up or merge.
+ * </p>
+ */
+package magmac.app.compile.error.context;

--- a/src/java/magmac/app/compile/error/error/package-info.java
+++ b/src/java/magmac/app/compile/error/error/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Error types for compile failures.
+ *
+ * <p>
+ * Recommendation: Small leaf package; no immediate need to break up or merge.
+ * </p>
+ */
+package magmac.app.compile.error.error;

--- a/src/java/magmac/app/compile/error/package-info.java
+++ b/src/java/magmac/app/compile/error/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Structures for compile errors.
+ *
+ * <p>
+ * Recommendation: Keep this package as a namespace with focused subpackages.
+ * </p>
+ */
+package magmac.app.compile.error;

--- a/src/java/magmac/app/compile/node/package-info.java
+++ b/src/java/magmac/app/compile/node/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Node transformation utilities.
+ *
+ * <p>
+ * Recommendation: Consider splitting into subpackages if more classes are added.
+ * </p>
+ */
+package magmac.app.compile.node;

--- a/src/java/magmac/app/compile/package-info.java
+++ b/src/java/magmac/app/compile/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Compiler orchestration classes.
+ *
+ * <p>
+ * Recommendation: Keep this package as a namespace with focused subpackages.
+ * </p>
+ */
+package magmac.app.compile;

--- a/src/java/magmac/app/compile/rule/divide/package-info.java
+++ b/src/java/magmac/app/compile/rule/divide/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Rules for dividing tokens.
+ *
+ * <p>
+ * Recommendation: Small leaf package; no immediate need to break up or merge.
+ * </p>
+ */
+package magmac.app.compile.rule.divide;

--- a/src/java/magmac/app/compile/rule/filter/package-info.java
+++ b/src/java/magmac/app/compile/rule/filter/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Token filter rules.
+ *
+ * <p>
+ * Recommendation: Small leaf package; no immediate need to break up or merge.
+ * </p>
+ */
+package magmac.app.compile.rule.filter;

--- a/src/java/magmac/app/compile/rule/fold/package-info.java
+++ b/src/java/magmac/app/compile/rule/fold/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Folding rules for block construction.
+ *
+ * <p>
+ * Recommendation: Small leaf package; no immediate need to break up or merge.
+ * </p>
+ */
+package magmac.app.compile.rule.fold;

--- a/src/java/magmac/app/compile/rule/locate/package-info.java
+++ b/src/java/magmac/app/compile/rule/locate/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Locator rules for selecting ranges.
+ *
+ * <p>
+ * Recommendation: Small leaf package; no immediate need to break up or merge.
+ * </p>
+ */
+package magmac.app.compile.rule.locate;

--- a/src/java/magmac/app/compile/rule/package-info.java
+++ b/src/java/magmac/app/compile/rule/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Base classes and shared logic for compiler rules.
+ *
+ * <p>
+ * Recommendation: Keep this package as a namespace with focused subpackages.
+ * </p>
+ */
+package magmac.app.compile.rule;

--- a/src/java/magmac/app/compile/rule/split/package-info.java
+++ b/src/java/magmac/app/compile/rule/split/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Token splitting rules.
+ *
+ * <p>
+ * Recommendation: Small leaf package; no immediate need to break up or merge.
+ * </p>
+ */
+package magmac.app.compile.rule.split;

--- a/src/java/magmac/app/config/package-info.java
+++ b/src/java/magmac/app/config/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Configuration for compiler targets and states.
+ *
+ * <p>
+ * Recommendation: Small leaf package; no immediate need to break up or merge.
+ * </p>
+ */
+package magmac.app.config;

--- a/src/java/magmac/app/error/package-info.java
+++ b/src/java/magmac/app/error/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Errors at the application level.
+ *
+ * <p>
+ * Recommendation: Small leaf package; no immediate need to break up or merge.
+ * </p>
+ */
+package magmac.app.error;

--- a/src/java/magmac/app/io/package-info.java
+++ b/src/java/magmac/app/io/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * I/O abstractions for reading and writing sources or targets.
+ *
+ * <p>
+ * Recommendation: Keep this package as a namespace with focused subpackages.
+ * </p>
+ */
+package magmac.app.io;

--- a/src/java/magmac/app/io/sources/package-info.java
+++ b/src/java/magmac/app/io/sources/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Source handling utilities.
+ *
+ * <p>
+ * Recommendation: Small leaf package; no immediate need to break up or merge.
+ * </p>
+ */
+package magmac.app.io.sources;

--- a/src/java/magmac/app/io/targets/package-info.java
+++ b/src/java/magmac/app/io/targets/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Target handling utilities.
+ *
+ * <p>
+ * Recommendation: Small leaf package; no immediate need to break up or merge.
+ * </p>
+ */
+package magmac.app.io.targets;

--- a/src/java/magmac/app/lang/common/package-info.java
+++ b/src/java/magmac/app/lang/common/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Common language constructs.
+ *
+ * <p>
+ * Recommendation: Small leaf package; no immediate need to break up or merge.
+ * </p>
+ */
+package magmac.app.lang.common;

--- a/src/java/magmac/app/lang/java/package-info.java
+++ b/src/java/magmac/app/lang/java/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Java specific constructs.
+ *
+ * <p>
+ * Recommendation: Consider splitting into subpackages if more classes are added.
+ * </p>
+ */
+package magmac.app.lang.java;

--- a/src/java/magmac/app/lang/node/package-info.java
+++ b/src/java/magmac/app/lang/node/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Node/JavaScript constructs.
+ *
+ * <p>
+ * Recommendation: Consider splitting into subpackages if more classes are added.
+ * </p>
+ */
+package magmac.app.lang.node;

--- a/src/java/magmac/app/lang/package-info.java
+++ b/src/java/magmac/app/lang/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Language-specific rules and structures.
+ *
+ * <p>
+ * Recommendation: Keep this package as a namespace with focused subpackages.
+ * </p>
+ */
+package magmac.app.lang;

--- a/src/java/magmac/app/lang/web/package-info.java
+++ b/src/java/magmac/app/lang/web/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Web platform constructs.
+ *
+ * <p>
+ * Recommendation: Small leaf package; no immediate need to break up or merge.
+ * </p>
+ */
+package magmac.app.lang.web;

--- a/src/java/magmac/app/package-info.java
+++ b/src/java/magmac/app/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Top level classes for the compiler application.
+ *
+ * <p>
+ * Recommendation: Keep this package as a namespace with focused subpackages.
+ * </p>
+ */
+package magmac.app;

--- a/src/java/magmac/app/stage/after/package-info.java
+++ b/src/java/magmac/app/stage/after/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Stages that run after generation.
+ *
+ * <p>
+ * Recommendation: Small leaf package; no immediate need to break up or merge.
+ * </p>
+ */
+package magmac.app.stage.after;

--- a/src/java/magmac/app/stage/generate/package-info.java
+++ b/src/java/magmac/app/stage/generate/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Generation stage interfaces.
+ *
+ * <p>
+ * Recommendation: Small leaf package; no immediate need to break up or merge.
+ * </p>
+ */
+package magmac.app.stage.generate;

--- a/src/java/magmac/app/stage/lexer/package-info.java
+++ b/src/java/magmac/app/stage/lexer/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Lexing stage.
+ *
+ * <p>
+ * Recommendation: Small leaf package; no immediate need to break up or merge.
+ * </p>
+ */
+package magmac.app.stage.lexer;

--- a/src/java/magmac/app/stage/package-info.java
+++ b/src/java/magmac/app/stage/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Compiler stages.
+ *
+ * <p>
+ * Recommendation: Keep this package as a namespace with focused subpackages.
+ * </p>
+ */
+package magmac.app.stage;

--- a/src/java/magmac/app/stage/parse/package-info.java
+++ b/src/java/magmac/app/stage/parse/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Parsing stage.
+ *
+ * <p>
+ * Recommendation: Small leaf package; no immediate need to break up or merge.
+ * </p>
+ */
+package magmac.app.stage.parse;

--- a/src/java/magmac/app/stage/result/package-info.java
+++ b/src/java/magmac/app/stage/result/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Pipeline result objects.
+ *
+ * <p>
+ * Recommendation: Small leaf package; no immediate need to break up or merge.
+ * </p>
+ */
+package magmac.app.stage.result;

--- a/src/java/magmac/app/stage/unit/package-info.java
+++ b/src/java/magmac/app/stage/unit/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Units of compilation.
+ *
+ * <p>
+ * Recommendation: Consider splitting into subpackages if more classes are added.
+ * </p>
+ */
+package magmac.app.stage.unit;

--- a/src/java/magmac/package-info.java
+++ b/src/java/magmac/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Entry point and high level APIs for the Magmac compiler.
+ *
+ * <p>
+ * Recommendation: Keep this package as a namespace with focused subpackages.
+ * </p>
+ */
+package magmac;


### PR DESCRIPTION
## Summary
- add package-info files across all Java packages
- each package-info explains the package purpose and suggests whether to break it up or keep as-is

## Testing
- `npm install`
- `javac --release 21 --enable-preview -d out $(find src/java -name '*.java')`
- `javac --release 21 --enable-preview -cp junit-platform-console-standalone.jar:out -d out $(find test/java -name '*.java')`
- `java --enable-preview -jar junit-platform-console-standalone.jar --class-path out --scan-class-path`

------
https://chatgpt.com/codex/tasks/task_e_683fbbe857848321802d7c28ec890c9a