### PR TITLE
Add documentation on Result wrappers

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -16,7 +16,21 @@ The `CompileApplication` ties everything together. It loads the source units, ru
 
 The relationships between the main classes are illustrated in `diagram.png` in this folder:
 
+
 ![Architecture Diagram](diagram.png)
+
+## Result Wrappers
+
+The compiler uses a generic `Result<T, E>` interface for operations that can
+fail. To avoid dragging specific error types through unrelated modules, small
+wrapper interfaces fix the error type and expose domain‑specific helpers. The
+existing `CompileResult` wraps `Result<T, CompileError>` for all compilation
+steps. IO utilities follow the same pattern with `IOResult` wrapping
+`Result<T, IOException>`.
+
+Several parts of the application still return `Result< T, ApplicationError>`
+directly. Introducing an `ApplicationResult` wrapper would mirror the compile
+and IO layers and keep high‑level error handling consistent across the codebase.
 
 ## Bootstrapping Approach
 


### PR DESCRIPTION
## Summary
- explain the result wrapper pattern in architecture docs

## Testing
- `javac --release 21 --enable-preview -d out $(find src/java -name '*.java')`
- `javac --release 21 --enable-preview -cp junit-platform-console-standalone.jar:out -d out $(find test/java -name '*.java')`
- `java --enable-preview -jar junit-platform-console-standalone.jar --class-path out --scan-class-path`


------
https://chatgpt.com/codex/tasks/task_e_683fbcf492ec8321a26fe3c423d11ae7