### PR TITLE
Add performance profiling documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ See [`docs/architecture.md`](docs/architecture.md) for an overview of how the co
 For details on how the PlantUML class diagram is generated see [`docs/diagram-generation.md`](docs/diagram-generation.md).
 The inspection report produced by IntelliJ is summarised in [`docs/inspection/tasks.md`](docs/inspection/tasks.md).
 For a high level roadmap and a list of missing Java→TypeScript features see [`docs/roadmap.md`](docs/roadmap.md).
+Suggestions for profiling the compiler's performance can be found in [`docs/performance-profiling.md`](docs/performance-profiling.md).
 
 Instance fields in the Java sources are always accessed using `this`. Java does
 not require it, but TypeScript does, and using the same convention avoids an

--- a/docs/performance-profiling.md
+++ b/docs/performance-profiling.md
@@ -1,0 +1,53 @@
+# Performance Profiling
+
+This document summarises practical ways to profile the Magmac compiler. The suggestions below focus on measuring execution time and memory usage for both the Java and TypeScript builds.
+
+## 1. Java Flight Recorder
+
+Java Flight Recorder (JFR) is bundled with modern JDKs and can capture CPU, memory and thread data.
+
+- Compile the project as normal using `javac`.
+- Run the compiler with a recording enabled:
+  ```bash
+  java -XX:StartFlightRecording=filename=magmac.jfr,duration=60s -cp out magmac.Main
+  ```
+- Open the resulting `magmac.jfr` file in Java Mission Control (`jmc`) to explore hotspots and allocation trends.
+
+For longer runs omit `duration` to record until the process exits. Recording settings can also be adjusted at runtime using `jcmd`.
+
+## 2. Microbenchmarks with JMH
+
+The [Java Microbenchmark Harness](https://openjdk.org/projects/code-tools/jmh/) helps measure small pieces of code in isolation. Add a benchmark module that depends on JMH and implement `@Benchmark` methods for critical functions. Running `mvn test` or `gradle jmh` (depending on the build tool) will produce scores in operations per second.
+
+JMH avoids common benchmarking pitfalls such as JIT warm‑up and dead code elimination.
+
+## 3. Profiling the TypeScript Build
+
+When running the TypeScript build of the compiler through Node.js you can collect V8 profiling data.
+
+- Execute `ts-node` with the `--cpu-prof` flag:
+  ```bash
+  ts-node --cpu-prof ./src/web/magmac/Main.ts
+  ```
+  This writes a `isolate-0x*.cpuprofile` file that can be loaded in Chrome DevTools.
+- For memory analysis use `--heap-prof` in a similar manner.
+
+Source maps generated during the TypeScript compilation allow you to map hot paths back to the original source files when examining the profile.
+
+## 4. Linux `perf`
+
+On Linux systems the `perf` tool can record low level events such as CPU cycles and cache misses.
+
+```bash
+perf record java -cp out magmac.Main
+perf report
+```
+
+`perf` works with both the JVM and the Node.js runtimes and can reveal expensive system calls or tight loops.
+
+## 5. In‑code Timing Helpers
+
+For quick checks add lightweight timing code around phases of the compiler. Java's `System.nanoTime()` and Node's `console.time()`/`console.timeEnd()` can highlight which stages contribute most to total runtime.
+
+Profiling results should be committed to the `docs` folder if they help track performance over time. Large raw data files (like `.jfr` or `.cpuprofile` dumps) are best kept out of version control.
+


### PR DESCRIPTION
## Summary
- add a new `performance-profiling` guide with suggestions for using JFR, JMH, Node profiling and Linux perf
- reference the new guide in the README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683fbfcb4160832182aaec1cbed21f09