### PR TITLE
Refactor long lambdas

### DIFF
--- a/src/java/magmac/app/compile/rule/LocatingRule.java
+++ b/src/java/magmac/app/compile/rule/LocatingRule.java
@@ -33,11 +33,15 @@ public final class LocatingRule implements Rule {
 
     @Override
     public CompileResult<Node> lex(String input) {
-        return this.splitter.split(input).map((Tuple2<String, String> tuple) -> {
-            var left = tuple.left();
-            var right = tuple.right();
-            return this.leftRule.lex(left).merge(() -> this.rightRule.lex(right), Node::merge);
-        }).orElseGet(() -> CompileErrors.createStringError(this.splitter.createMessage(), input));
+        return this.splitter.split(input)
+                .map(this::lexPair)
+                .orElseGet(() -> CompileErrors.createStringError(this.splitter.createMessage(), input));
+    }
+
+    private CompileResult<Node> lexPair(Tuple2<String, String> tuple) {
+        var left = tuple.left();
+        var right = tuple.right();
+        return this.leftRule.lex(left).merge(() -> this.rightRule.lex(right), Node::merge);
     }
 
     @Override

--- a/src/java/magmac/app/compile/rule/LocatingSplitter.java
+++ b/src/java/magmac/app/compile/rule/LocatingSplitter.java
@@ -7,11 +7,14 @@ import magmac.app.compile.rule.locate.Locator;
 public record LocatingSplitter(String infix, Locator locator) implements Splitter {
     @Override
     public Option<Tuple2<String, String>> split(String input) {
-        return this.locator.locate(input, this.infix).map((Integer separator) -> {
-            var left = input.substring(0, separator);
-            var right = input.substring(separator + this.infix.length());
-            return new Tuple2<>(left, right);
-        });
+        return this.locator.locate(input, this.infix)
+                .map(separator -> this.splitAt(input, separator));
+    }
+
+    private Tuple2<String, String> splitAt(String input, int separator) {
+        var left = input.substring(0, separator);
+        var right = input.substring(separator + this.infix.length());
+        return new Tuple2<>(left, right);
     }
 
     @Override

--- a/src/java/magmac/app/io/targets/PathTargets.java
+++ b/src/java/magmac/app/io/targets/PathTargets.java
@@ -24,20 +24,22 @@ public record PathTargets(Path root, String extension) implements Targets {
     }
 
     private Option<IOException> write(Unit<String> entry) {
-        return entry.destruct((Location location, String output) -> {
-            var targetParent = location.namespace()
-                    .iter()
-                    .fold(this.root, Path::resolve);
+        return entry.destruct(this::writePair);
+    }
 
-            if (!Files.exists(targetParent)) {
-                var maybeError = SafeFiles.createDirectories(targetParent);
-                if (maybeError.isPresent()) {
-                    return maybeError;
-                }
+    private Option<IOException> writePair(Location location, String output) {
+        var targetParent = location.namespace()
+                .iter()
+                .fold(this.root, Path::resolve);
+
+        if (!Files.exists(targetParent)) {
+            var maybeError = SafeFiles.createDirectories(targetParent);
+            if (maybeError.isPresent()) {
+                return maybeError;
             }
+        }
 
-            var target = targetParent.resolve(location.name() + "." + this.extension);
-            return SafeFiles.writeString(target, output);
-        });
+        var target = targetParent.resolve(location.name() + "." + this.extension);
+        return SafeFiles.writeString(target, output);
     }
 }


### PR DESCRIPTION
## Summary
- simplify lambda usage by extracting helpers in PathTargets
- extract lex helper for LocatingRule
- create splitAt helper for LocatingSplitter
- factor out node mapping in CompoundDestructorImpl

## Testing
- `javac --release 21 --enable-preview -d out $(find src/java -name '*.java')`
- `curl -L -o junit-platform-console-standalone.jar https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/1.10.1/junit-platform-console-standalone-1.10.1.jar`
- `javac --release 21 --enable-preview -cp junit-platform-console-standalone.jar:out -d out $(find test/java -name '*.java')`
- `java --enable-preview -jar junit-platform-console-standalone.jar --class-path out --scan-class-path`


------
https://chatgpt.com/codex/tasks/task_e_683fbff16e4083219355d299cfece6d9