### PR TITLE
Improve Indentation and add unit tests

### DIFF
--- a/src/java/magmac/app/compile/rule/StripRule.java
+++ b/src/java/magmac/app/compile/rule/StripRule.java
@@ -3,11 +3,12 @@ package magmac.app.compile.rule;
 import magmac.app.compile.error.CompileResult;
 import magmac.app.compile.node.Node;
 
-public record StripRule(String beforeKey, Rule rule, String afterKey) implements Rule {
-    public StripRule(Rule rule) {
-        this("", rule, "");
-    }
-
+/**
+ * Rule that trims input before lexing and appends optional strings when
+ * generating output.  The strings are read from {@code before} and
+ * {@code after} keys on the node and default to empty if absent.
+ */
+public record StripRule(Rule rule) implements Rule {
     @Override
     public CompileResult<Node> lex(String input) {
         return this.rule.lex(input.strip());
@@ -15,8 +16,8 @@ public record StripRule(String beforeKey, Rule rule, String afterKey) implements
 
     @Override
     public CompileResult<String> generate(Node node) {
-        var before = node.findString(this.beforeKey).orElse("");
-        var after = node.findString(this.afterKey).orElse("");
-        return this.rule.generate(node).mapValue((String result) -> before + result + after);
+        var before = node.findString("before").orElse("");
+        var after = node.findString("after").orElse("");
+        return this.rule.generate(node).mapValue(result -> before + result + after);
     }
 }

--- a/src/java/magmac/app/lang/java/JavaMethod.java
+++ b/src/java/magmac/app/lang/java/JavaMethod.java
@@ -44,7 +44,7 @@ public record JavaMethod(
 
         var parameters = JavaRules.createParametersRule(JavaRules.createDefinitionRule());
         var content = CommonLang.Statements("children", childRule);
-        Rule rightRule = new StripRule(new PrefixRule("{", new SuffixRule(new StripRule("", content, "after-children"), "}")));
+        Rule rightRule = new StripRule(new PrefixRule("{", new SuffixRule(new StripRule(content), "}")));
         Rule withParams = new OptionNodeListRule("parameters",
                 new SuffixRule(parameters, ");"),
                 LocatingRule.First(parameters, ")", rightRule)

--- a/src/java/magmac/app/lang/node/FunctionSegments.java
+++ b/src/java/magmac/app/lang/node/FunctionSegments.java
@@ -44,7 +44,7 @@ public final class FunctionSegments {
                 JavaRules.createCaseRule(value, functionSegmentRule)
         ));
 
-        return functionSegmentRule.set(new StripRule("before", rule, ""));
+        return functionSegmentRule.set(new StripRule(rule));
     }
 
 }

--- a/src/java/magmac/app/lang/web/Indentation.java
+++ b/src/java/magmac/app/lang/web/Indentation.java
@@ -1,0 +1,55 @@
+package magmac.app.lang.web;
+
+import magmac.api.Tuple2;
+import magmac.api.iter.Iter;
+import magmac.app.compile.node.Node;
+import magmac.app.compile.node.NodeList;
+
+/**
+ * Applies indentation information to TypeScript AST nodes. Each node receives
+ * a "before" string and optionally an "after" string used by {@link StripRule}
+ * during generation.
+ */
+public final class Indentation {
+    private Indentation() {}
+
+    public static Node apply(Node root) {
+        root.findNodeList("children").ifPresent(list -> {
+            var iter = list.iter();
+            var maybe = iter.next();
+            while (maybe.isPresent()) {
+                var child = maybe.orElse(null);
+                indent(child, 0);
+                maybe = iter.next();
+            }
+        });
+        return root;
+    }
+
+    private static void indent(Node node, int depth) {
+        node.withString("before", createIndent(depth));
+        if (node.is("block") || node.is("method") || node.is("class")
+                || node.is("interface") || node.is("enum")) {
+            node.withString("after", createIndent(depth));
+        } else {
+            node.withString("after", "");
+        }
+
+        Iter<Tuple2<String, NodeList>> lists = node.iterNodeLists();
+        var maybeList = lists.next();
+        while (maybeList.isPresent()) {
+            NodeList childList = maybeList.orElse(null).right();
+            var iter = childList.iter();
+            var maybeChild = iter.next();
+            while (maybeChild.isPresent()) {
+                indent(maybeChild.orElse(null), depth + 1);
+                maybeChild = iter.next();
+            }
+            maybeList = lists.next();
+        }
+    }
+
+    private static String createIndent(int depth) {
+        return "\n" + "\t".repeat(Math.max(depth, 0));
+    }
+}

--- a/src/java/magmac/app/lang/web/TypescriptLang.java
+++ b/src/java/magmac/app/lang/web/TypescriptLang.java
@@ -19,6 +19,7 @@ import magmac.app.lang.node.ParameterizedMethodHeader;
 import magmac.app.lang.node.PostVariant;
 import magmac.app.lang.node.Segment;
 import magmac.app.lang.node.StructureValue;
+import magmac.app.lang.web.Indentation;
 
 public final class TypescriptLang {
     /** Argument to a TypeScript function call. */
@@ -124,8 +125,9 @@ public final class TypescriptLang {
     public record TypescriptRoot(List<TypeScriptRootSegment> children) implements Serializable {
         @Override
         public Node serialize() {
-            return new MapNode("root")
+            Node node = new MapNode("root")
                     .withNodeListAndSerializer("children", this.children, TypeScriptRootSegment::serialize);
+            return Indentation.apply(node);
         }
     }
 

--- a/src/java/magmac/app/lang/web/TypescriptRules.java
+++ b/src/java/magmac/app/lang/web/TypescriptRules.java
@@ -52,7 +52,7 @@ public final class TypescriptRules {
         LazyRule functionSegmentRule = new MutableLazyRule();
         var value = JavaRules.initValueRule(functionSegmentRule, valueLazy, " => ", definition);
         var children = CommonLang.Statements("children", FunctionSegments.initFunctionSegmentRule(functionSegmentRule, value, definition));
-        Rule childRule = new SuffixRule(LocatingRule.First(header, " {", new StripRule("", children, "after-children")), "}");
+        Rule childRule = new SuffixRule(LocatingRule.First(header, " {", new StripRule(children)), "}");
         return new TypeRule("method", new OptionNodeListRule("children",
                 childRule,
                 new SuffixRule(header, ";")

--- a/test/java/magmac/app/compile/rule/StripRuleTest.java
+++ b/test/java/magmac/app/compile/rule/StripRuleTest.java
@@ -1,0 +1,29 @@
+package magmac.app.compile.rule;
+
+import magmac.app.compile.error.CompileResult;
+import magmac.app.compile.node.MapNode;
+import magmac.app.compile.node.Node;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class StripRuleTest {
+    @Test
+    public void trimsWhitespaceOnLex() {
+        Rule rule = new StripRule(new StringRule("value"));
+        CompileResult<Node> result = rule.lex("  hi  ");
+        Node node = result.toResult().match(v -> v, e -> { throw new RuntimeException(e.display()); });
+        assertEquals("hi", node.findString("value").orElse(null));
+    }
+
+    @Test
+    public void usesBeforeAfterOnGenerate() {
+        Rule rule = new StripRule(new StringRule("value"));
+        Node node = new MapNode()
+                .withString("value", "x")
+                .withString("before", "<")
+                .withString("after", ">");
+        String generated = rule.generate(node).toResult().match(v -> v, e -> { throw new RuntimeException(e.display()); });
+        assertEquals("<x>", generated);
+    }
+}

--- a/test/java/magmac/app/lang/web/IndentationTest.java
+++ b/test/java/magmac/app/lang/web/IndentationTest.java
@@ -1,0 +1,32 @@
+package magmac.app.lang.web;
+
+import magmac.app.compile.node.InlineNodeList;
+import magmac.app.compile.node.MapNode;
+import magmac.app.compile.node.Node;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class IndentationTest {
+    @Test
+    public void addsIndentationToStructure() {
+        Node block = new MapNode("block").withNodeList("children", InlineNodeList.empty());
+        Node method = new MapNode("method").withNodeList("children", InlineNodeList.of(block));
+        Node clazz = new MapNode("class").withNodeList("members", InlineNodeList.of(method));
+        Node root = new MapNode("root").withNodeList("children", InlineNodeList.of(clazz));
+
+        Indentation.apply(root);
+
+        Node classOut = root.findNodeList("children").orElse(null).iter().next().orElse(null);
+        assertEquals("\n", classOut.findString("before").orElse(null));
+        assertEquals("\n", classOut.findString("after").orElse(null));
+
+        Node methodOut = classOut.findNodeList("members").orElse(null).iter().next().orElse(null);
+        assertEquals("\n\t", methodOut.findString("before").orElse(null));
+        assertEquals("\n\t", methodOut.findString("after").orElse(null));
+
+        Node blockOut = methodOut.findNodeList("children").orElse(null).iter().next().orElse(null);
+        assertEquals("\n\t\t", blockOut.findString("before").orElse(null));
+        assertEquals("\n\t\t", blockOut.findString("after").orElse(null));
+    }
+}


### PR DESCRIPTION
## Summary
- rework `Indentation` to avoid undefined `forEach`
- test the simplified `StripRule`
- add test verifying TypeScript indentation

## Testing
- `javac --release 21 --enable-preview -d out $(find src/java -name '*.java')`
- `javac --release 21 --enable-preview -cp junit-platform-console-standalone.jar:out -d out $(find test/java -name '*.java')`
- `java --enable-preview -jar junit-platform-console-standalone.jar --class-path out --scan-class-path`

------
https://chatgpt.com/codex/tasks/task_e_683fbef0016483218ed2d47e98e51bb0