### PR TITLE
Fix odd names

### DIFF
--- a/src/java/magmac/app/compile/error/CompileResult.java
+++ b/src/java/magmac/app/compile/error/CompileResult.java
@@ -2,7 +2,7 @@ package magmac.app.compile.error;
 
 import magmac.api.Tuple2;
 import magmac.api.result.Result;
-import magmac.app.compile.error.error.CompileError;
+import magmac.app.compile.error.type.CompileError;
 
 import java.util.function.BiFunction;
 import java.util.function.Function;

--- a/src/java/magmac/app/compile/error/CompileResults.java
+++ b/src/java/magmac/app/compile/error/CompileResults.java
@@ -6,7 +6,7 @@ import magmac.api.result.Result;
 import magmac.app.compile.error.context.Context;
 import magmac.app.compile.error.context.NodeContext;
 import magmac.app.compile.error.context.StringContext;
-import magmac.app.compile.error.error.CompileError;
+import magmac.app.compile.error.type.CompileError;
 import magmac.app.compile.node.Node;
 import magmac.app.error.ImmutableCompileError;
 

--- a/src/java/magmac/app/compile/error/InlineCompileResult.java
+++ b/src/java/magmac/app/compile/error/InlineCompileResult.java
@@ -2,7 +2,7 @@ package magmac.app.compile.error;
 
 import magmac.api.Tuple2;
 import magmac.api.result.Result;
-import magmac.app.compile.error.error.CompileError;
+import magmac.app.compile.error.type.CompileError;
 
 import java.util.function.BiFunction;
 import java.util.function.Function;

--- a/src/java/magmac/app/compile/error/type/CompileError.java
+++ b/src/java/magmac/app/compile/error/type/CompileError.java
@@ -1,4 +1,4 @@
-package magmac.app.compile.error.error;
+package magmac.app.compile.error.type;
 
 import magmac.api.collect.list.List;
 import magmac.api.error.Error;

--- a/src/java/magmac/app/compile/error/type/CompileErrors.java
+++ b/src/java/magmac/app/compile/error/type/CompileErrors.java
@@ -1,4 +1,4 @@
-package magmac.app.compile.error.error;
+package magmac.app.compile.error.type;
 
 import magmac.api.result.Err;
 import magmac.app.compile.error.CompileResult;

--- a/src/java/magmac/app/compile/error/type/package-info.java
+++ b/src/java/magmac/app/compile/error/type/package-info.java
@@ -5,4 +5,4 @@
  * Recommendation: Small leaf package; no immediate need to break up or merge.
  * </p>
  */
-package magmac.app.compile.error.error;
+package magmac.app.compile.error.type;

--- a/src/java/magmac/app/compile/node/MapNode.java
+++ b/src/java/magmac/app/compile/node/MapNode.java
@@ -13,7 +13,7 @@ import magmac.api.iter.collect.Joiner;
 import magmac.api.result.Ok;
 import magmac.app.compile.error.CompileResult;
 import magmac.app.compile.error.CompileResults;
-import magmac.app.compile.error.error.CompileErrors;
+import magmac.app.compile.error.type.CompileErrors;
 
 import java.util.function.BiFunction;
 import java.util.function.Function;

--- a/src/java/magmac/app/compile/rule/ContextRule.java
+++ b/src/java/magmac/app/compile/rule/ContextRule.java
@@ -3,7 +3,7 @@ package magmac.app.compile.rule;
 import magmac.api.collect.list.Lists;
 import magmac.app.compile.error.CompileResult;
 import magmac.app.compile.error.context.NodeContext;
-import magmac.app.compile.error.error.CompileError;
+import magmac.app.compile.error.type.CompileError;
 import magmac.app.compile.node.Node;
 import magmac.app.compile.error.context.StringContext;
 import magmac.app.error.ImmutableCompileError;

--- a/src/java/magmac/app/compile/rule/ExactRule.java
+++ b/src/java/magmac/app/compile/rule/ExactRule.java
@@ -3,7 +3,7 @@ package magmac.app.compile.rule;
 import magmac.api.result.Ok;
 import magmac.app.compile.error.CompileResult;
 import magmac.app.compile.error.CompileResults;
-import magmac.app.compile.error.error.CompileErrors;
+import magmac.app.compile.error.type.CompileErrors;
 import magmac.app.compile.node.MapNode;
 import magmac.app.compile.node.Node;
 

--- a/src/java/magmac/app/compile/rule/FilterRule.java
+++ b/src/java/magmac/app/compile/rule/FilterRule.java
@@ -1,7 +1,7 @@
 package magmac.app.compile.rule;
 
 import magmac.app.compile.error.CompileResult;
-import magmac.app.compile.error.error.CompileErrors;
+import magmac.app.compile.error.type.CompileErrors;
 import magmac.app.compile.node.Node;
 import magmac.app.compile.rule.filter.Filter;
 import magmac.app.compile.rule.filter.NumberFilter;

--- a/src/java/magmac/app/compile/rule/LocatingRule.java
+++ b/src/java/magmac/app/compile/rule/LocatingRule.java
@@ -2,7 +2,7 @@ package magmac.app.compile.rule;
 
 import magmac.api.Tuple2;
 import magmac.app.compile.error.CompileResult;
-import magmac.app.compile.error.error.CompileErrors;
+import magmac.app.compile.error.type.CompileErrors;
 import magmac.app.compile.node.Node;
 import magmac.app.compile.rule.locate.FirstLocator;
 import magmac.app.compile.rule.locate.LastLocator;

--- a/src/java/magmac/app/compile/rule/OrState.java
+++ b/src/java/magmac/app/compile/rule/OrState.java
@@ -10,7 +10,7 @@ import magmac.api.result.Ok;
 import magmac.app.compile.error.CompileResult;
 import magmac.app.compile.error.CompileResults;
 import magmac.app.compile.error.context.Context;
-import magmac.app.compile.error.error.CompileError;
+import magmac.app.compile.error.type.CompileError;
 import magmac.app.error.ImmutableCompileError;
 
 record OrState<T>(Option<T> maybeValue, List<CompileError> errors) {

--- a/src/java/magmac/app/compile/rule/PrefixRule.java
+++ b/src/java/magmac/app/compile/rule/PrefixRule.java
@@ -1,7 +1,7 @@
 package magmac.app.compile.rule;
 
 import magmac.app.compile.error.CompileResult;
-import magmac.app.compile.error.error.CompileErrors;
+import magmac.app.compile.error.type.CompileErrors;
 import magmac.app.compile.node.Node;
 
 public record PrefixRule(String prefix, Rule childRule) implements Rule {

--- a/src/java/magmac/app/compile/rule/StringRule.java
+++ b/src/java/magmac/app/compile/rule/StringRule.java
@@ -3,7 +3,7 @@ package magmac.app.compile.rule;
 import magmac.api.result.Ok;
 import magmac.app.compile.error.CompileResult;
 import magmac.app.compile.error.CompileResults;
-import magmac.app.compile.error.error.CompileErrors;
+import magmac.app.compile.error.type.CompileErrors;
 import magmac.app.compile.node.MapNode;
 import magmac.app.compile.node.Node;
 

--- a/src/java/magmac/app/compile/rule/SuffixRule.java
+++ b/src/java/magmac/app/compile/rule/SuffixRule.java
@@ -1,7 +1,7 @@
 package magmac.app.compile.rule;
 
 import magmac.app.compile.error.CompileResult;
-import magmac.app.compile.error.error.CompileErrors;
+import magmac.app.compile.error.type.CompileErrors;
 import magmac.app.compile.node.Node;
 
 public record SuffixRule(Rule childRule, String suffix) implements Rule {

--- a/src/java/magmac/app/compile/rule/TypeRule.java
+++ b/src/java/magmac/app/compile/rule/TypeRule.java
@@ -5,8 +5,8 @@ import magmac.app.compile.error.CompileResult;
 import magmac.app.compile.error.context.Context;
 import magmac.app.compile.error.context.NodeContext;
 import magmac.app.compile.error.context.StringContext;
-import magmac.app.compile.error.error.CompileError;
-import magmac.app.compile.error.error.CompileErrors;
+import magmac.app.compile.error.type.CompileError;
+import magmac.app.compile.error.type.CompileErrors;
 import magmac.app.compile.node.Node;
 import magmac.app.error.ImmutableCompileError;
 

--- a/src/java/magmac/app/error/ImmutableCompileError.java
+++ b/src/java/magmac/app/error/ImmutableCompileError.java
@@ -6,7 +6,7 @@ import magmac.api.collect.list.Lists;
 import magmac.api.iter.collect.Joiner;
 import magmac.api.iter.collect.Max;
 import magmac.app.compile.error.context.Context;
-import magmac.app.compile.error.error.CompileError;
+import magmac.app.compile.error.type.CompileError;
 
 public record ImmutableCompileError(String message, Context context,
                                     List<CompileError> errors) implements CompileError {

--- a/src/java/magmac/app/lang/Deserializers.java
+++ b/src/java/magmac/app/lang/Deserializers.java
@@ -7,7 +7,7 @@ import magmac.api.iter.Iters;
 import magmac.app.compile.error.CompileResult;
 import magmac.app.compile.error.CompileResults;
 import magmac.app.compile.error.context.NodeContext;
-import magmac.app.compile.error.error.CompileError;
+import magmac.app.compile.error.type.CompileError;
 import magmac.app.compile.node.Node;
 import magmac.app.error.ImmutableCompileError;
 import magmac.app.lang.node.TypedDeserializer;

--- a/src/java/magmac/app/lang/MutableLazyRule.java
+++ b/src/java/magmac/app/lang/MutableLazyRule.java
@@ -4,7 +4,7 @@ import magmac.api.None;
 import magmac.api.Option;
 import magmac.api.Some;
 import magmac.app.compile.error.CompileResult;
-import magmac.app.compile.error.error.CompileErrors;
+import magmac.app.compile.error.type.CompileErrors;
 import magmac.app.compile.node.Node;
 import magmac.app.compile.rule.Rule;
 

--- a/src/java/magmac/app/stage/StagePass.java
+++ b/src/java/magmac/app/stage/StagePass.java
@@ -7,7 +7,7 @@ import magmac.app.stage.result.ParseResult;
 /**
  * Performs a single pass over a parse tree.
  */
-public interface Passer {
+public interface StagePass {
     /**
      * Processes the given {@code node} within the provided parse state.
      */

--- a/src/java/magmac/app/stage/generate/RuleGenerator.java
+++ b/src/java/magmac/app/stage/generate/RuleGenerator.java
@@ -4,7 +4,7 @@ import magmac.api.collect.list.Lists;
 import magmac.app.compile.error.CompileResult;
 import magmac.app.compile.error.CompileResultCollector;
 import magmac.app.compile.error.context.NodeContext;
-import magmac.app.compile.error.error.CompileError;
+import magmac.app.compile.error.type.CompileError;
 import magmac.app.compile.node.Node;
 import magmac.app.compile.rule.Rule;
 import magmac.app.error.ImmutableCompileError;


### PR DESCRIPTION
## Summary
- rename `magmac.app.compile.error.error` package to `magmac.app.compile.error.type`
- rename the `Passer` interface to `StagePass`
- update all imports and references

## Testing
- `javac --release 21 --enable-preview -d out $(find src/java -name '*.java')`
- `curl -L -o junit-platform-console-standalone.jar https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/1.10.1/junit-platform-console-standalone-1.10.1.jar`
- `javac --release 21 --enable-preview -cp junit-platform-console-standalone.jar:out -d out $(find test/java -name '*.java')`
- `java --enable-preview -jar junit-platform-console-standalone.jar --class-path out --scan-class-path`

------
https://chatgpt.com/codex/tasks/task_e_683fc3eb5d5c8321874b7f57ac39a79e