### PR TITLE
Expand DecoratedFolder tests

### DIFF
--- a/test/java/magmac/app/compile/rule/fold/DecoratedFolderTest.java
+++ b/test/java/magmac/app/compile/rule/fold/DecoratedFolderTest.java
@@ -54,4 +54,36 @@ public class DecoratedFolderTest {
         var segments = this.divide("\"a\\\"b,c\",d");
         assertEquals(java.util.List.of("\"a\\\"b,c\"", "d"), segments);
     }
+
+    @Test
+    public void testCommentMarkersInsideQuotes() {
+        var segments = this.divide("a,'//b',c");
+        assertEquals(java.util.List.of("a", "'//b'", "c"), segments);
+        segments = this.divide("a,\"/*b*/\",c");
+        assertEquals(java.util.List.of("a", "\"/*b*/\"", "c"), segments);
+    }
+
+    @Test
+    public void testQuotesInsideBlockComment() {
+        var segments = this.divide("a,/*'b,c'*/d,e");
+        assertEquals(java.util.List.of("a", "/*'b,c'*/", "d", "e"), segments);
+    }
+
+    @Test
+    public void testBlockCommentWithNewline() {
+        var segments = this.divide("a,/*b\nc*/d,e");
+        assertEquals(java.util.List.of("a", "/*b\nc*/", "d", "e"), segments);
+    }
+
+    @Test
+    public void testLineCommentNoNewline() {
+        var segments = this.divide("a,//b,c");
+        assertEquals(java.util.List.of("a", "//b,c"), segments);
+    }
+
+    @Test
+    public void testMultilineDoubleQuote() {
+        var segments = this.divide("a,\"b\nc\",d");
+        assertEquals(java.util.List.of("a", "\"b\nc\"", "d"), segments);
+    }
 }


### PR DESCRIPTION
## Summary
- extend `DecoratedFolderTest` with cases for comments and multiline values

## Testing
- `javac --release 21 --enable-preview -d out -cp junit-platform-console-standalone.jar @sources.txt`
- `java --enable-preview -jar junit-platform-console-standalone.jar -cp out --scan-class-path`

------
https://chatgpt.com/codex/tasks/task_e_683fc668ab448321a059ed7dcd2d691a