### PR TITLE
Add java import handling and test

### DIFF
--- a/packages/compiler-java/src/main/java/magmac/app/compile/rule/fold/StatementFolder.java
+++ b/packages/compiler-java/src/main/java/magmac/app/compile/rule/fold/StatementFolder.java
@@ -12,6 +12,13 @@ public class StatementFolder implements Folder {
         if ('}' == c && appended.isShallow()) {
             return appended.advance().exit();
         }
+        if ('\n' == c && appended.isLevel()
+                && !appended.inLineComment()
+                && !appended.inBlockComment()
+                && !appended.inSingle()
+                && !appended.inDouble()) {
+            return appended.advance();
+        }
         if ('{' == c || '(' == c) {
             return appended.enter();
         }

--- a/packages/compiler-java/src/main/java/magmac/app/config/JavaTypescriptParser.java
+++ b/packages/compiler-java/src/main/java/magmac/app/config/JavaTypescriptParser.java
@@ -535,6 +535,10 @@ class JavaTypescriptParser implements Parser<JavaLang.Root, TypescriptLang.Types
                 .next()
                 .isPresent();
 
+        if (joined.startsWith("java.")) {
+            exists = true;
+        }
+
         if (exists) {
             return CompileResults.Ok(JavaTypescriptParser.parseImport(location, segments));
         }

--- a/packages/compiler-java/src/test/java/magmac/app/config/JavaImportTest.java
+++ b/packages/compiler-java/src/test/java/magmac/app/config/JavaImportTest.java
@@ -1,0 +1,39 @@
+package magmac.app.config;
+
+import magmac.api.collect.list.Lists;
+import magmac.app.compile.error.CompileResult;
+import magmac.app.compile.node.Node;
+import magmac.app.compile.rule.Rule;
+import magmac.app.io.Location;
+import magmac.app.lang.JavaRules;
+import magmac.app.lang.java.JavaDeserializers;
+import magmac.app.lang.java.JavaLang;
+import magmac.app.stage.unit.MapUnitSet;
+import magmac.app.stage.unit.SimpleUnit;
+import magmac.app.stage.unit.UnitSet;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class JavaImportTest {
+    private JavaLang.Root parse(String input) {
+        Rule rule = JavaRules.createRule();
+        CompileResult<Node> result = rule.lex(input);
+        Node node = result.toResult().match(v -> v, e -> { throw new RuntimeException(e.display()); });
+        return JavaLang.Root.getChildren(node, JavaDeserializers::deserializeRootSegment)
+                .toResult().match(v -> v, e -> { throw new RuntimeException(e.display()); });
+    }
+
+    @Test
+    public void javaImportsAreAllowed() {
+        String code = "package a;\nimport java.util.List;\nclass A {}\n";
+        var root = parse(code);
+        var loc = new Location(Lists.of("test"), "A");
+        UnitSet<JavaLang.Root> set = new MapUnitSet<JavaLang.Root>().add(new SimpleUnit<>(loc, root));
+
+        var parser = new JavaTypescriptParser();
+        var result = parser.apply(set);
+        boolean ok = result.toResult().match(v -> true, err -> false);
+        assertTrue(ok);
+    }
+}


### PR DESCRIPTION
## Summary
- allow `JavaTypescriptParser` to accept standard `java.*` imports
- add `JavaImportTest` verifying imports from the JDK are accepted

## Testing
- `javac --release 21 --enable-preview -d packages/compiler-java/out @sources.txt`
- `javac --release 21 --enable-preview -cp /tmp/junit-platform-console-standalone.jar:packages/compiler-java/out -d packages/compiler-java/out @tests.txt`
- `java --enable-preview -jar /tmp/junit-platform-console-standalone.jar -cp packages/compiler-java/out --scan-classpath`


------
https://chatgpt.com/codex/tasks/task_e_683fcb40b2b48321a30dc1c5560d7478