### PR TITLE
Fix NPM install path in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           node-version: '20'
           cache: 'npm'
+          cache-dependency-path: packages/compiler-ts/package-lock.json
 
       - name: Install dependencies
         working-directory: packages/compiler-ts
@@ -61,6 +62,7 @@ jobs:
         with:
           node-version: '20'
           cache: 'npm'
+          cache-dependency-path: packages/compiler-ts/package-lock.json
 
       - name: Install dependencies
         working-directory: packages/compiler-ts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Build Java
         run: |
           mkdir -p out
-          javac --release 21 --enable-preview -d out $(find src/java -name '*.java')
+          javac --release 21 --enable-preview -d out $(find packages/compiler-java/src/main/java -name '*.java')
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
@@ -77,5 +77,5 @@ jobs:
       - name: Run Java tests
         run: |
           curl -L -o junit-platform-console-standalone.jar https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/1.10.1/junit-platform-console-standalone-1.10.1.jar
-          javac --release 21 --enable-preview -cp junit-platform-console-standalone.jar:out -d out $(find test/java -name '*.java')
+          javac --release 21 --enable-preview -cp junit-platform-console-standalone.jar:out -d out $(find packages/compiler-java/src/test/java -name '*.java')
           java --enable-preview -jar junit-platform-console-standalone.jar --class-path out --scan-class-path

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
+        working-directory: packages/compiler-ts
         run: npm install
 
       # The TypeScript version of the compiler isn't ready yet so we skip
@@ -62,6 +63,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
+        working-directory: packages/compiler-ts
         run: npm install
 
       - name: Download build artifacts


### PR DESCRIPTION
## Summary
- update GitHub Actions to run `npm install` from `packages/compiler-ts`

## Testing
- `npm install --prefix packages/compiler-ts`


------
https://chatgpt.com/codex/tasks/task_e_683fd60120088321acfc1b31a5cf63ec