### PR TITLE
Improve docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,18 @@ java -cp packages/compiler-java/out magmac.Main
 
 This will scan the sources, run the compiler pipeline and write the generated outputs to the directories configured by each `TargetPlatform` (for example `diagrams` for PlantUML files and `src/web` for TypeScript files).
 
+### TypeScript build
+
+A recent Node.js runtime (version 18 or newer is recommended) is required to experiment with the TypeScript version of the compiler. From the repository root install the dependencies and launch the entry point:
+
+```bash
+cd packages/compiler-ts
+npm install
+npm start
+```
+
+The script executes `ts-node` and runs the TypeScript build of `magmac.Main`.
+
 Primitive Java types are translated to their TypeScript equivalents. Numeric primitives
 (`byte`, `short`, `int`, `long`, `float`, `double`) become `number`, `boolean` stays
 `boolean` and `char` or `String` are emitted as `string`.

--- a/docs/performance-profiling.md
+++ b/docs/performance-profiling.md
@@ -30,6 +30,8 @@ When running the TypeScript build of the compiler through Node.js you can collec
   ts-node --cpu-prof ./src/web/magmac/Main.ts
   ```
   This writes a `isolate-0x*.cpuprofile` file that can be loaded in Chrome DevTools.
+- Pass `--cpu-prof-dir <dir>` or `--cpu-prof-name <name>` to control where the
+  profile is written.
 - For memory analysis use `--heap-prof` in a similar manner.
 
 Source maps generated during the TypeScript compilation allow you to map hot paths back to the original source files when examining the profile.


### PR DESCRIPTION
## Summary
- expand setup instructions for running the TypeScript build
- clarify profiling docs for `ts-node`

## Testing
- `npm install` in `packages/compiler-ts`
- `npm start` *(fails: Cannot find module './Main.ts')*

------
https://chatgpt.com/codex/tasks/task_e_683fd946bf908321acb65532ccbc04df