### PR TITLE
Add architecture improvements doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Primitive Java types are translated to their TypeScript equivalents. Numeric pri
 - `docs/` – Documentation and architecture diagrams
 
 See [`docs/architecture.md`](docs/architecture.md) for an overview of how the compiler is structured.
+General refactoring plans are tracked in [`docs/architecture-improvements.md`](docs/architecture-improvements.md).
 For details on how the PlantUML class diagram is generated see [`docs/diagram-generation.md`](docs/diagram-generation.md).
 The inspection report produced by IntelliJ is summarised in [`docs/inspection/tasks.md`](docs/inspection/tasks.md).
 For a high level roadmap and a list of missing Java→TypeScript features see [`docs/roadmap.md`](docs/roadmap.md).

--- a/docs/architecture-improvements.md
+++ b/docs/architecture-improvements.md
@@ -1,0 +1,22 @@
+# Ongoing Architectural Improvements
+
+This document collects general plans and ideas for refining the compiler's design. The goal is to reduce coupling between modules and make it easier to add new back ends in the future.
+
+## Reduce Tight Coupling
+
+- **Split large classes into smaller components** so that each class has a single responsibility.
+- **Introduce clearer package boundaries** to minimise circular dependencies.
+- **Move static helper methods** closer to their call sites or make them private where possible.
+
+## Consistent Result Wrappers
+
+Many parts of the code already wrap operations that can fail in domain‑specific `Result` types. Some modules still return `Result<T, ApplicationError>` directly. Introducing an `ApplicationResult` wrapper would mirror `CompileResult` and `IOResult`, keeping error handling consistent across the compiler.
+
+## Modularity and Interfaces
+
+- Consider reorganising the project into smaller modules. An explicit module structure makes dependencies obvious and encourages interface‑driven design.
+- Expose narrow interfaces for public APIs and keep implementation details package‑private.
+
+## Future Work
+
+These improvements are incremental. Refactoring should be accompanied by updated tests and documentation. Tracking progress in `docs/inspection/tasks.md` helps highlight remaining issues.


### PR DESCRIPTION
## Summary
- document ongoing architectural improvements
- reference new doc from the README

## Testing
- `javac --release 21 --enable-preview -d out $(find packages/compiler-java/src/main/java -name '*.java')`
- `javac --release 21 --enable-preview -cp junit-platform-console-standalone.jar:out -d out $(find packages/compiler-java/src/test/java -name '*.java')`
- `java --enable-preview -jar junit-platform-console-standalone.jar --class-path out --scan-class-path`

------
https://chatgpt.com/codex/tasks/task_e_683fdabb743c83219f66d1dd6753f590